### PR TITLE
test: rewrite built-in command tests and sync docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,9 +442,11 @@ The CLI automatically scans the current working directory and its subdirectories
 
 ## Development notes
 
-- **Library vs CLI**: import `@jshow/cli` for `CommandProgram` / `BaseCommand` / `utils`; run `jshow` (or `pnpm start` in this repo) for cwd auto-discovery. Implementation entry points: `src/index.ts` (library), `src/cli.ts` → `dist/cli.mjs` (CLI).
-- **Built-in commands**: wired in `src/built-in/commands/index.ts`; add new classes there and document them in this README.
-- **JSDoc**: public and internal helpers in `src/` are documented next to implementations—prefer reading source JSDoc over duplicating API lists here.
+- **Library vs CLI**: import `@jshow/cli` for `CommandProgram` / `BaseCommand` / `utils`; run `jshow` (or `pnpm start` in this repo) for cwd auto-discovery. Entry points: `src/index.ts` (library), `src/cli.ts` → `dist/cli.mjs` (CLI). `runjShow` is exported from `src/cli.ts` for tests/custom wrappers but **not** from the package main entry.
+- **Discovery resilience**: a broken `.cmd` / `.plugin` in the workspace logs a warning only so `--help` and built-ins still run (`loadCommand` / `loadPlugin`).
+- **Boolean `invert`**: for `flagValue: false` options, `invert: true` also registers `--no-<name>` (used by built-in `backup -c`, `release --check` / `--push`, etc.); see `initOption` in `src/command.ts`.
+- **Built-in commands**: registered in `src/built-in/commands/index.ts`; see `docs/*.md` for flow details and this README for a summary.
+- **JSDoc**: public and internal helpers in `src/` are documented next to implementations—prefer source JSDoc over duplicating API lists here.
 
 ---
 
@@ -472,6 +474,7 @@ The CLI automatically scans the current working directory and its subdirectories
 │   ├── built-in/       # Default commands/plugins wired by initBuiltIn
 │   └── utils/          # Workspace scan, git, pnpm, fs helpers
 ├── test/               # Vitest specs and fixtures (not published)
+├── docs/               # Built-in command docs (backup / release / upgrade)
 ├── examples/           # Sample .cmd / .plugin files
 ├── scripts/            # Dev helpers (e.g. run-cli-help.mjs)
 ├── dist/               # Vite build output (gitignored)

--- a/README_CN.md
+++ b/README_CN.md
@@ -443,8 +443,10 @@ CLI 会自动扫描当前工作目录及其子目录，查找所有 `.cmd.ts`、
 
 ## 开发说明
 
-- **库与 CLI 分工**：`import '@jshow/cli'` 使用 `CommandProgram` / `BaseCommand` / `utils`；执行 `jshow`（或在本仓库 `pnpm start`）才会扫描 cwd。实现入口：`src/index.ts`（库）、`src/cli.ts` → `dist/cli.mjs`（CLI）。
-- **内置命令**：在 `src/built-in/commands/index.ts` 注册；新增后请同步更新本文「内置命令」一节。
+- **库与 CLI 分工**：`import '@jshow/cli'` 使用 `CommandProgram` / `BaseCommand` / `utils`；执行 `jshow`（或在本仓库 `pnpm start`）才会扫描 cwd。实现入口：`src/index.ts`（库）、`src/cli.ts` → `dist/cli.mjs`（CLI）。`src/cli.ts` 导出 `runjShow` 供测试或二次封装，**不**从包主入口再导出。
+- **命令发现**：工作区内 `.cmd` / `.plugin` 加载失败仅 `warn`，不阻断 `--help` 与内置命令（见 `loadCommand` / `loadPlugin`）。
+- **布尔选项 `invert`**：在 `CommandOption` 上对 `flagValue: false` 的开关可设 `invert: true`，框架会额外注册 `--no-<name>`（内置 `backup -c`、`release --check` / `--push` 等）；语义见 `src/command.ts` 的 `initOption`。
+- **内置命令**：在 `src/built-in/commands/index.ts` 注册；行为细节见 `docs/*.md`，摘要见本文「内置命令」。
 - **JSDoc**：`src/` 下公共与内部辅助函数均在源码旁维护文档，API 细节以 JSDoc 为准，本文不重复罗列每个符号。
 
 ---
@@ -473,6 +475,7 @@ CLI 会自动扫描当前工作目录及其子目录，查找所有 `.cmd.ts`、
 │   ├── built-in/       # initBuiltIn 注册的默认命令/插件
 │   └── utils/          # 工作区扫描、git、pnpm、fs 等
 ├── test/               # Vitest 与 fixtures（不参与包发布）
+├── docs/               # 内置命令说明（backup / release / upgrade）
 ├── examples/           # 示例 .cmd / .plugin
 ├── scripts/            # 开发辅助脚本（如 run-cli-help.mjs）
 ├── dist/               # Vite 构建输出（通常 gitignore）

--- a/src/built-in/commands/backup.cmd.ts
+++ b/src/built-in/commands/backup.cmd.ts
@@ -37,6 +37,8 @@ const GIT_DIR = '.git';
 
 /**
  * 将 Git 仓库根目录转为备份目标条目。
+ * @param dir - 仓库根绝对路径
+ * @returns 合成 `PackageInfo`（`manifest.version` 固定为 `0.0.0`）
  * @internal
  */
 const toGitPackageInfo = (dir: string): PackageInfo => {
@@ -50,6 +52,11 @@ const toGitPackageInfo = (dir: string): PackageInfo => {
 
 /**
  * 自 `root` 起递归查找含 `.git` 的目录，每个仓库根视为一个工作区包。
+ * @param root - 扫描起点
+ * @param max - 最大递归深度，默认 {@link GIT_SCAN_MAX_DEPTH}
+ * @param level - 当前深度（内部递归用）
+ * @param packages - 累积结果（内部递归用）
+ * @returns 发现的 Git 仓库列表
  * @description 命中 `.git` 后不再向下扫描，避免把子模块或嵌套仓重复计入。
  * @internal
  */
@@ -82,6 +89,9 @@ const discoverGitPackages = (
 
 /**
  * 将 `getGroupPackages` 结果展开为待备份的包目录列表。
+ * @param inputRoot - 用户传入的输入目录（无 manifest 时用于 {@link discoverGitPackages}）
+ * @param groups - `getGroupPackages` 返回值
+ * @returns 待备份的 `PackageInfo` 列表
  * @description monorepo 根（含 `children`）时备份各子包；无 manifest 时回退为 `.git` 仓库扫描。
  * @internal
  */
@@ -186,9 +196,12 @@ const copyPackage = async (
  * @internal
  */
 interface BackupOptions extends CommandOptionsType {
-  /** 是否在输出侧排除 `.git` */
+  /**
+   * 复制时是否排除源目录下的 `.git`（始终排除 `node_modules`）。
+   * @description CLI 声明 `invert: true` 且默认 `true`，对应 `-c` / `--clean`。
+   */
   clean: boolean;
-  /** 逗号分隔包名过滤模式，见 {@link toPatterns} */
+  /** 逗号分隔的**包名**过滤模式，见 {@link toPatterns}（非文件路径） */
   filter?: string;
 }
 
@@ -200,7 +213,7 @@ interface BackupOptions extends CommandOptionsType {
  *
  * // 运行示例：
  * jshow backup ./code ./code_backup
- * jshow backup ./core ./core_backup -c -f "*.test.ts"
+ * jshow backup ./core ./core_backup -c -f "@scope/pkg-a"
  * ```
  */
 export class BackupCommand extends BaseCommand<BackupOptions> {
@@ -213,7 +226,7 @@ export class BackupCommand extends BaseCommand<BackupOptions> {
       description: 'Backup workspace packages to output directory',
       examples: [
         'jshow backup ./code ./code_backup',
-        'jshow backup ./core ./core_backup -c -f "*.test.ts"'
+        'jshow backup ./core ./core_backup -c -f "@scope/pkg-a"'
       ],
       arguments: [
         {
@@ -232,17 +245,24 @@ export class BackupCommand extends BaseCommand<BackupOptions> {
           name: 'clean',
           abbr: 'c',
           description: 'Clean output .git directory',
-          defaultValue: true
+          defaultValue: true,
+          invert: true
         },
         {
           name: 'filter',
           abbr: 'f',
-          description: 'The filter pattern'
+          description: 'The filter pattern',
+          flagValue: true
         }
       ]
     };
   }
 
+  /**
+   * 解析输入/输出目录，拉取并复制各备份目标到输出根下以包名命名的子目录。
+   * @param context - Commander 解析后的参数与选项
+   * @returns Promise<void>；无目标时 `process.exit(1)`
+   */
   public async execute({
     args,
     options: { clean, filter = '' }

--- a/src/built-in/commands/release.cmd.ts
+++ b/src/built-in/commands/release.cmd.ts
@@ -596,13 +596,19 @@ const releaseMonrepoPackage = async (
  * @internal
  */
 interface ReleaseOptions extends CommandOptionsType {
-  /** 发版前是否检查工作区干净 */
+  /**
+   * 发版前是否检查工作区干净。
+   * @description CLI 默认 `true` 且 `invert: true`（对应 `-c` / `--check`）。
+   */
   check: boolean;
-  /** 预选 `semver` release type（如 `patch`） */
+  /** 预选 `semver` release type（如 `patch`）；非法值则进入交互 */
   type?: string;
-  /** 是否跳过确认提示 */
+  /** 跳过 bump 汇总确认（多仓仍会先 checkbox 选包） */
   force: boolean;
-  /** 是否在提交后 `git push` */
+  /**
+   * 是否在提交后 `git push`。
+   * @description CLI 默认 `true` 且 `invert: true`（对应 `-p` / `--push`）。
+   */
   push: boolean;
 }
 
@@ -614,7 +620,7 @@ interface ReleaseReport {
   name: string;
   /** 处理的包数量（mono 为子包数） */
   count: number;
-  /** 该段流程是否产生并成功完成升级 */
+  /** 该段流程是否成功完成发版 */
   status: boolean;
 }
 
@@ -652,12 +658,14 @@ export class ReleaseCommand extends BaseCommand<ReleaseOptions> {
           name: 'check',
           abbr: 'c',
           description: 'Check the release',
-          defaultValue: true
+          defaultValue: true,
+          invert: true
         },
         {
           name: 'type',
           abbr: 't',
-          description: 'Release type mode'
+          description: 'Release type mode',
+          flagValue: true
         },
         {
           name: 'force',
@@ -669,12 +677,18 @@ export class ReleaseCommand extends BaseCommand<ReleaseOptions> {
           name: 'push',
           abbr: 'p',
           description: 'Push the release to the remote repository',
-          defaultValue: true
+          defaultValue: true,
+          invert: true
         }
       ]
     };
   }
 
+  /**
+   * 扫描工作区并依次处理多独立包与 monorepo 根发版流程，末尾输出 Report 表。
+   * @param context - Commander 解析后的参数与选项
+   * @returns Promise<void>
+   */
   public async execute({
     args,
     options

--- a/src/built-in/commands/upgrade.cmd.ts
+++ b/src/built-in/commands/upgrade.cmd.ts
@@ -1,8 +1,8 @@
 /**
  * @fileoverview `upgrade` 内置命令
  * @description
- * 扫描工作区内多仓或 monorepo，汇总依赖引用关系，查询 registry 可升级版本；
- * 经交互选择后写回 `package.json`、执行 `pnpm install`，并可选择提交与推送。
+ * 扫描工作区内多仓或 monorepo，汇总依赖引用关系；
+ * 先多选依赖名再查询 registry，经字段级确认后写回 `package.json`、`pnpm install`，并可选择提交与推送。
  * `--local` 已声明但尚未接入执行逻辑。
  */
 
@@ -104,7 +104,7 @@ interface UpgradeMonorepoParams extends UpgradeParams {
   ROOT_DIR: string;
   /** 根包 `package.json` 解析结果 */
   ROOT_JSON: PackageJson;
-  /** pnpm catalog 锁定版本 */
+  /** 预留：catalog 锁定版本缓存（当前未写入） */
   CATALOG_VERSIONS: Record<string, string>;
   /** 工作区内本地包名/版本，用于 `pnpm search` 命中时标记 `workspace:*` */
   LOCAL_VERSIONS: Omit<PackageData, 'items'>[];
@@ -299,8 +299,10 @@ const filterRootVersions = (
 };
 
 /**
- * 多选待升级的依赖包名。
- * @returns 用户勾选的 `PackageData` 子集；未选任何项时返回 `[]`
+ * 多选待查询 registry 的依赖名（在 `pnpm info` 之前执行）。
+ * @param log - 作用域日志
+ * @param versions - {@link filterRootVersions} 得到的候选列表
+ * @returns 用户勾选的子集；未选任何项时返回 `[]`
  * @internal
  */
 const selectForUpgradePackages = async (
@@ -777,7 +779,7 @@ const upgradeMultiFiles = async (
 
 /**
  * 在 `cwd` 下可选执行 `git add`、多行 `commitGit` 与 `pushGit`。
- * @description `--force` 时跳过提交与推送确认；无 `git diff` 输出则直接返回；仅当 `options.push` 为真时执行 push。
+ * @description `--force` 时跳过提交与推送确认；`getUnCommittedFiles` 为空则跳过提交；仅当 `options.push` 为真时执行 push。
  * @internal
  */
 const commitChangeFiles = async (
@@ -942,7 +944,7 @@ export interface UpgradeOptions extends CommandOptionsType {
   /** 是否在 monorepo 内优先解析本地包版本（已声明，执行逻辑待接） */
   local: boolean;
   /** 逗号分隔的依赖名忽略模式，见 {@link toPatterns} */
-  ignore: string;
+  ignore?: string;
   /** 为真时跳过提交与推送的交互确认（仍会受 `push` 控制是否实际 push） */
   force: boolean;
   /** 写回并提交后是否执行 `git push`（默认 `true`） */
@@ -1001,7 +1003,8 @@ export class UpgradeCommand extends BaseCommand<UpgradeOptions> {
         {
           name: 'ignore',
           abbr: 'i',
-          description: 'The ignore packages'
+          description: 'The ignore packages',
+          flagValue: true
         },
         {
           name: 'force',
@@ -1013,12 +1016,18 @@ export class UpgradeCommand extends BaseCommand<UpgradeOptions> {
           name: 'push',
           abbr: 'p',
           description: 'Push the upgrade to the remote repository',
-          defaultValue: true
+          defaultValue: true,
+          invert: true
         }
       ]
     };
   }
 
+  /**
+   * 扫描工作区依赖升级：multi 与 monorepo 不可混跑，末尾输出 Report 表。
+   * @param context - Commander 解析后的参数与选项
+   * @returns Promise<void>；混跑布局时 `process.exit(1)`
+   */
   public async execute({
     args,
     options: { ignore, ...options }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,8 @@ const BUILT_IN_COMMAND_PATH = path.normalize(
 
 /**
  * 判断路径是否位于 CLI 自带的 `built-in/commands` 目录下。
+ * @param fn - 待检查的文件或目录路径
+ * @returns 若位于内置命令目录树内则为 `true`
  * @description 避免把包内已注册的内置命令再当作用户项目文件扫描一遍。
  * @internal
  */
@@ -189,7 +191,10 @@ const loadPlugin = async (fn: string, log: typeof logger): Promise<void> => {
     // 注册插件
     CommandProgram.install(plugin, plugin.force);
   } catch (error) {
-    log.warn(`加载插件文件 "${fn}" 时出错:`, error);
+    log.warn(
+      `加载插件文件 "${fn}" 时出错`,
+      error instanceof Error ? error.message : String(error)
+    );
   }
 };
 
@@ -238,7 +243,10 @@ const loadCommand = async (fn: string, log: typeof logger): Promise<void> => {
   } catch (error) {
     // 外部工作目录里的命令文件可能依赖其自身的运行环境（依赖未装、模块格式不兼容等）。
     // 这里降级为 warn，避免单个命令文件导致整个 CLI（包括 --help）无法启动。
-    log.warn(`加载命令文件 "${fn}" 时出错:`, error);
+    log.warn(
+      `加载命令文件 "${fn}" 时出错`,
+      error instanceof Error ? error.message : String(error)
+    );
   }
 };
 
@@ -292,8 +300,9 @@ export const runjShow = async (): Promise<void> => {
   await runPromise;
 };
 
+// 作为可执行入口立即启动；失败时非零退出，避免静默成功
 void runjShow().catch((err: unknown) => {
-  // 顶层启动失败时给出可读信息并非零退出，便于 CI/脚本判断
+  // 顶层启动失败时给出可读信息并 exit(1)，便于 CI/脚本判断
   logger.error(
     '❌ 启动失败:',
     err instanceof Error ? err.message : String(err)

--- a/src/command.ts
+++ b/src/command.ts
@@ -68,6 +68,12 @@ export interface CommandOption extends CommandArgument {
    * @default false
    */
   flagValue?: boolean;
+  /**
+   * 是否为布尔开关额外注册 `--no-<name>`。
+   * @description 仅当 `flagValue` 为 `false`（布尔开关）时生效；{@link initOption} 会再挂载一条 `--no-${name}`，常与 `defaultValue: true` 搭配（如 `backup -c`、`release --check`）。
+   * @default false
+   */
+  invert?: boolean;
 }
 
 /**
@@ -205,6 +211,34 @@ const getOptionFlag = (item: CommandOption) => {
   if (item.flagValue) flags.push(getArgumentFlag(item));
 
   return flags.join(' ');
+};
+
+/**
+ * 将 {@link CommandArgument} 挂载为 Commander 位置参数。
+ * @internal
+ */
+const initArgument = (program: Command, item: CommandArgument) => {
+  program.argument(getArgumentFlag(item), item.description, item.defaultValue);
+};
+
+/**
+ * 将 {@link CommandOption} 挂载为 Commander 选项；`invert` 时为布尔开关追加 `--no-<name>`。
+ * @internal
+ */
+const initOption = (program: Command, item: CommandOption) => {
+  const flags = [getOptionFlag(item)];
+  if (item.abbr) flags.unshift(`-${item.abbr}`);
+  let flag = flags.join(', ');
+
+  program.option(flag, item.description, item.defaultValue);
+
+  if (!item.flagValue && item.invert) {
+    // 默认 true 的开关需要显式负选项，否则用户无法关闭（如 --no-push）
+    flag = getOptionFlag(item);
+    flag = flag.replace(`--${item.name}`, `--no-${item.name}`);
+
+    program.option(flag);
+  }
 };
 
 /**
@@ -359,17 +393,13 @@ export abstract class BaseCommand<
     }
 
     // 设置命令参数
-    for (const { description, defaultValue, ...item } of args.arguments ?? []) {
-      program.argument(getArgumentFlag(item), description, defaultValue);
+    for (const item of args.arguments ?? []) {
+      initArgument(program, item);
     }
 
     // 自动注册选项
-    for (const { abbr, description, defaultValue, ...item } of args.options ??
-      []) {
-      const flags = [getOptionFlag(item)];
-      if (abbr) flags.unshift(`-${abbr}`);
-
-      program.option(flags.join(', '), description, defaultValue);
+    for (const item of args.options ?? []) {
+      initOption(program, item);
     }
 
     // 添加使用示例

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -228,11 +228,9 @@ const buildCommitFile = (name: string, msgs: string[]) => {
  * ```ts
  * import os from 'node:os';
  * import path from 'node:path';
- * import { commitGitByFile, writeFileSync } from '@jshow/cli';
+ * import { commitGit } from '@jshow/cli';
  *
- * const msg = path.join(os.tmpdir(), 'commit_msg');
- * writeFileSync(msg, 'chore: update', '', '- details');
- * commitGitByFile(msg);
+ * commitGit(['chore: update', '', '- details']);
  * ```
  */
 const commitGitByFile = (fn: string, cwd?: string) => {

--- a/test/built-in/commands/backup.cmd.test.ts
+++ b/test/built-in/commands/backup.cmd.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 /**
  * @fileoverview 内置命令 `backup` 契约测试
+ * @description 对齐 `backup.cmd.ts`：manifest 子包 / 单包 / `.git` 回退扫描；一级目录复制。
  */
 
 import path from 'node:path';
@@ -44,260 +45,282 @@ describe('BackupCommand', () => {
     vi.mocked(utils.eachDirSync).mockImplementation((_root, cb) => {
       (cb as (name: string) => void)('lib');
     });
+    vi.mocked(utils.pullCurrentBranch).mockImplementation(() => {});
   });
 
   afterEach(() => vi.clearAllMocks());
 
-  it('static key 应为 backup', () => {
-    expect(BackupCommand.key).toBe('backup');
+  describe('CLI 声明', () => {
+    it('static key 应为 backup', () => {
+      expect(BackupCommand.key).toBe('backup');
+    });
+
+    it('args 应声明 input/output 与 clean、filter 选项', () => {
+      const { args } = backup;
+      expect(args.name).toBe('backup');
+      expect(args.group).toBe('devOps');
+      expect(args.arguments?.map(a => a.name)).toEqual(['input', 'output']);
+      expect(args.arguments?.[0]?.required).toBe(true);
+      expect(args.arguments?.[1]?.defaultValue).toBe('../backup');
+      expect(args.options?.map(o => o.name)).toEqual(['clean', 'filter']);
+      expect(args.options?.find(o => o.name === 'clean')).toMatchObject({
+        defaultValue: true,
+        invert: true
+      });
+      expect(args.options?.find(o => o.name === 'filter')?.flagValue).toBe(
+        true
+      );
+    });
   });
 
-  it('args 应声明 input/output 位置参数与 clean、filter 选项', () => {
-    const { args } = backup;
-    expect(args.name).toBe('backup');
-    expect(args.group).toBe('devOps');
-    expect(args.arguments?.map(a => a.name)).toEqual(['input', 'output']);
-    expect(args.options?.map(o => o.name)).toEqual(['clean', 'filter']);
-  });
-
-  it('有 .git 时应 pull，再 mkdir 并 cpSync 一级子项', async () => {
-    await backup.execute({
-      name: 'backup',
-      args: ['/ws', '/out'],
-      options: { filter: '', clean: true },
-      startTime: Date.now()
-    });
-
-    expect(utils.getGroupPackages).toHaveBeenCalledWith(path.resolve('/ws'));
-    expect(utils.pullCurrentBranch).toHaveBeenCalledWith(
-      true,
-      pkgA.dir,
-      expect.any(Boolean)
-    );
-    expect(utils.mkdirSync).toHaveBeenCalled();
-    expect(utils.cpSync).toHaveBeenCalledTimes(1);
-    const [from, to] = vi.mocked(utils.cpSync).mock.calls[0];
-    expect(from).toMatch(/[/\\]lib$/);
-    expect(to).toMatch(/[/\\]a[/\\]lib$/);
-  });
-
-  it('无 .git 时不应 pull', async () => {
-    vi.mocked(utils.existsSync).mockReturnValue(false);
-
-    await backup.execute({
-      name: 'backup',
-      args: ['/ws', '/out'],
-      options: { filter: '', clean: true },
-      startTime: Date.now()
-    });
-
-    expect(utils.pullCurrentBranch).not.toHaveBeenCalled();
-    expect(utils.cpSync).toHaveBeenCalled();
-  });
-
-  it('monorepo 有 children 时应备份各子包而非仅根目录', async () => {
-    const pkgAChild = path.resolve('/ws/packages/a');
-    const pkgBChild = path.resolve('/ws/packages/b');
-
-    vi.mocked(utils.getGroupPackages).mockReturnValue([
-      {
-        dir: path.resolve('/ws'),
-        name: 'root',
-        manifest: { name: 'root', version: '0.0.0', private: true },
-        children: [
-          {
-            dir: pkgAChild,
-            name: '@scope/a',
-            manifest: { name: '@scope/a', version: '0.0.0' }
-          },
-          {
-            dir: pkgBChild,
-            name: '@scope/b',
-            manifest: { name: '@scope/b', version: '0.0.0' }
-          }
-        ]
-      }
-    ]);
-    vi.mocked(utils.existsSync).mockImplementation(p => {
-      const v = String(p).replace(/\\/g, '/');
-      return v.endsWith('/.git');
-    });
-
-    await backup.execute({
-      name: 'backup',
-      args: [path.resolve('/ws'), path.resolve('/out')],
-      options: { filter: '', clean: true },
-      startTime: Date.now()
-    });
-
-    expect(utils.pullCurrentBranch).toHaveBeenCalledTimes(2);
-    expect(utils.mkdirSync).toHaveBeenCalledTimes(2);
-    const mkdirPaths = vi.mocked(utils.mkdirSync).mock.calls.map(c => c[0]);
-    expect(mkdirPaths.some(p => p.endsWith(`${path.sep}a`))).toBe(true);
-    expect(mkdirPaths.some(p => p.endsWith(`${path.sep}b`))).toBe(true);
-  });
-
-  it('无 package.json 时应按各 .git 仓库以此备份', async () => {
-    const inputRoot = path.resolve('/ws');
-    const outputRoot = path.resolve('/out');
-    const repoA = path.join(inputRoot, 'repo-a');
-    const repoB = path.join(inputRoot, 'repo-b');
-
-    vi.mocked(utils.getGroupPackages).mockReturnValue([]);
-    vi.mocked(utils.existsSync).mockImplementation(p => {
-      const v = path.resolve(String(p));
-      if (v === path.join(repoA, '.git') || v === path.join(repoB, '.git')) {
-        return true;
-      }
-      return v === inputRoot || v === repoA || v === repoB;
-    });
-    vi.mocked(utils.eachDirSync).mockImplementation((root, cb) => {
-      const r = path.resolve(String(root));
-      if (r === inputRoot) {
-        for (const name of ['repo-a', 'repo-b']) {
-          (cb as (name: string, ph: string) => void)(name, path.join(r, name));
-        }
-        return;
-      }
-      (cb as (name: string) => void)('lib');
-    });
-
-    await backup.execute({
-      name: 'backup',
-      args: [inputRoot, outputRoot],
-      options: { filter: '', clean: true },
-      startTime: Date.now()
-    });
-
-    expect(utils.mkdirSync).toHaveBeenCalledTimes(2);
-    const mkdirPaths = vi.mocked(utils.mkdirSync).mock.calls.map(c => c[0]);
-    expect(mkdirPaths).toContain(path.join(outputRoot, 'repo-a'));
-    expect(mkdirPaths).toContain(path.join(outputRoot, 'repo-b'));
-    expect(utils.cpSync).toHaveBeenCalled();
-  });
-
-  it('input 根目录自身含 .git 时应作为单个仓库备份', async () => {
-    const inputRoot = path.resolve('/ws');
-    const outputRoot = path.resolve('/out');
-
-    vi.mocked(utils.getGroupPackages).mockReturnValue([]);
-    vi.mocked(utils.existsSync).mockImplementation(p => {
-      const v = path.resolve(String(p));
-      return v === inputRoot || v === path.join(inputRoot, '.git');
-    });
-
-    await backup.execute({
-      name: 'backup',
-      args: [inputRoot, outputRoot],
-      options: { filter: '', clean: true },
-      startTime: Date.now()
-    });
-
-    expect(utils.mkdirSync).toHaveBeenCalledWith(
-      path.join(outputRoot, path.basename(inputRoot))
-    );
-  });
-
-  it('filter 应按包名正则过滤（使用真实 toPatterns）', async () => {
-    vi.mocked(utils.getGroupPackages).mockReturnValue([
-      { ...pkgA, dir: '/ws/p1', name: '@scope/keep' },
-      {
-        dir: '/ws/p2',
-        name: '@scope/skip',
-        manifest: { name: '@scope/skip', version: '0.0.0' },
-        children: []
-      }
-    ]);
-
-    await backup.execute({
-      name: 'backup',
-      args: ['/ws', '/out'],
-      options: { filter: '^@scope/keep$', clean: true },
-      startTime: Date.now()
-    });
-
-    expect(utils.pullCurrentBranch).toHaveBeenCalledTimes(1);
-    expect(utils.pullCurrentBranch).toHaveBeenCalledWith(
-      true,
-      '/ws/p1',
-      expect.any(Boolean)
-    );
-  });
-
-  it('clean=true 时应跳过 node_modules 与 .git', async () => {
-    vi.mocked(utils.eachDirSync).mockImplementation((_root, cb) => {
-      for (const name of ['node_modules', '.git', 'src']) {
-        (cb as (name: string) => void)(name);
-      }
-    });
-
-    await backup.execute({
-      name: 'backup',
-      args: ['/ws', '/out'],
-      options: { filter: '', clean: true },
-      startTime: Date.now()
-    });
-
-    const copied = vi.mocked(utils.cpSync).mock.calls.map(c => c[0]);
-    expect(copied.some(p => p.endsWith(`${path.sep}node_modules`))).toBe(false);
-    expect(copied.some(p => p.endsWith(`${path.sep}.git`))).toBe(false);
-    expect(copied.some(p => p.endsWith(`${path.sep}src`))).toBe(true);
-  });
-
-  it('无任何备份目标时应 exit(1)', async () => {
-    vi.mocked(utils.getGroupPackages).mockReturnValue([]);
-    vi.mocked(utils.existsSync).mockReturnValue(false);
-
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code = 1) => {
-      throw new Error(`exit:${code}`);
-    });
-
-    await expect(
-      backup.execute({
+  describe('execute', () => {
+    it('有 .git 时应 pull，再 mkdir 并 cpSync 一级子项', async () => {
+      await backup.execute({
         name: 'backup',
-        args: ['/empty', '/out'],
+        args: ['/ws', '/out'],
         options: { filter: '', clean: true },
         startTime: Date.now()
-      })
-    ).rejects.toThrow('exit:1');
+      });
 
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(utils.cpSync).not.toHaveBeenCalled();
-    exitSpy.mockRestore();
-  });
-
-  it('pull 失败时不应阻断后续 copy', async () => {
-    vi.mocked(utils.pullCurrentBranch).mockImplementation(() => {
-      throw new Error('pull failed');
+      expect(utils.getGroupPackages).toHaveBeenCalledWith(path.resolve('/ws'));
+      expect(utils.pullCurrentBranch).toHaveBeenCalledWith(
+        true,
+        pkgA.dir,
+        expect.any(Boolean)
+      );
+      expect(utils.mkdirSync).toHaveBeenCalled();
+      expect(utils.cpSync).toHaveBeenCalledTimes(1);
+      const [from, to] = vi.mocked(utils.cpSync).mock.calls[0];
+      expect(from).toMatch(/[/\\]lib$/);
+      expect(to).toMatch(/[/\\]a[/\\]lib$/);
     });
 
-    await backup.execute({
-      name: 'backup',
-      args: ['/ws', '/out'],
-      options: { filter: '', clean: true },
-      startTime: Date.now()
+    it('无 .git 时不应 pull', async () => {
+      vi.mocked(utils.existsSync).mockReturnValue(false);
+
+      await backup.execute({
+        name: 'backup',
+        args: ['/ws', '/out'],
+        options: { filter: '', clean: true },
+        startTime: Date.now()
+      });
+
+      expect(utils.pullCurrentBranch).not.toHaveBeenCalled();
+      expect(utils.cpSync).toHaveBeenCalled();
     });
 
-    expect(utils.cpSync).toHaveBeenCalled();
-  });
+    it('monorepo 有 children 时应备份各子包而非仅根目录', async () => {
+      const pkgAChild = path.resolve('/ws/packages/a');
+      const pkgBChild = path.resolve('/ws/packages/b');
 
-  it('clean=false 时应复制 .git，仍跳过 node_modules', async () => {
-    vi.mocked(utils.eachDirSync).mockImplementation((_root, cb) => {
-      for (const name of ['node_modules', '.git', 'src']) {
-        (cb as (name: string) => void)(name);
-      }
+      vi.mocked(utils.getGroupPackages).mockReturnValue([
+        {
+          dir: path.resolve('/ws'),
+          name: 'root',
+          manifest: { name: 'root', version: '0.0.0', private: true },
+          children: [
+            {
+              dir: pkgAChild,
+              name: '@scope/a',
+              manifest: { name: '@scope/a', version: '0.0.0' }
+            },
+            {
+              dir: pkgBChild,
+              name: '@scope/b',
+              manifest: { name: '@scope/b', version: '0.0.0' }
+            }
+          ]
+        }
+      ]);
+      vi.mocked(utils.existsSync).mockImplementation(p => {
+        const v = String(p).replace(/\\/g, '/');
+        return v.endsWith('/.git');
+      });
+
+      await backup.execute({
+        name: 'backup',
+        args: [path.resolve('/ws'), path.resolve('/out')],
+        options: { filter: '', clean: true },
+        startTime: Date.now()
+      });
+
+      expect(utils.pullCurrentBranch).toHaveBeenCalledTimes(2);
+      expect(utils.mkdirSync).toHaveBeenCalledTimes(2);
+      const mkdirPaths = vi.mocked(utils.mkdirSync).mock.calls.map(c => c[0]);
+      expect(mkdirPaths.some(p => p.endsWith(`${path.sep}a`))).toBe(true);
+      expect(mkdirPaths.some(p => p.endsWith(`${path.sep}b`))).toBe(true);
     });
 
-    await backup.execute({
-      name: 'backup',
-      args: ['/ws', '/out'],
-      options: { filter: '', clean: false },
-      startTime: Date.now()
+    it('无 package.json 时应按各 .git 仓库分别备份', async () => {
+      const inputRoot = path.resolve('/ws');
+      const outputRoot = path.resolve('/out');
+      const repoA = path.join(inputRoot, 'repo-a');
+      const repoB = path.join(inputRoot, 'repo-b');
+
+      vi.mocked(utils.getGroupPackages).mockReturnValue([]);
+      vi.mocked(utils.existsSync).mockImplementation(p => {
+        const v = path.resolve(String(p));
+        if (v === path.join(repoA, '.git') || v === path.join(repoB, '.git')) {
+          return true;
+        }
+        return v === inputRoot || v === repoA || v === repoB;
+      });
+      vi.mocked(utils.eachDirSync).mockImplementation((root, cb) => {
+        const r = path.resolve(String(root));
+        if (r === inputRoot) {
+          for (const name of ['repo-a', 'repo-b']) {
+            (cb as (name: string, ph: string) => void)(
+              name,
+              path.join(r, name)
+            );
+          }
+          return;
+        }
+        (cb as (name: string) => void)('lib');
+      });
+
+      await backup.execute({
+        name: 'backup',
+        args: [inputRoot, outputRoot],
+        options: { filter: '', clean: true },
+        startTime: Date.now()
+      });
+
+      expect(utils.mkdirSync).toHaveBeenCalledTimes(2);
+      const mkdirPaths = vi.mocked(utils.mkdirSync).mock.calls.map(c => c[0]);
+      expect(mkdirPaths).toContain(path.join(outputRoot, 'repo-a'));
+      expect(mkdirPaths).toContain(path.join(outputRoot, 'repo-b'));
     });
 
-    const copied = vi.mocked(utils.cpSync).mock.calls.map(c => c[0]);
-    expect(copied.some(p => p.endsWith(`${path.sep}node_modules`))).toBe(false);
-    expect(copied.some(p => p.endsWith(`${path.sep}.git`))).toBe(true);
-    expect(copied.some(p => p.endsWith(`${path.sep}src`))).toBe(true);
+    it('input 根目录自身含 .git 时应作为单个仓库备份', async () => {
+      const inputRoot = path.resolve('/ws');
+      const outputRoot = path.resolve('/out');
+
+      vi.mocked(utils.getGroupPackages).mockReturnValue([]);
+      vi.mocked(utils.existsSync).mockImplementation(p => {
+        const v = path.resolve(String(p));
+        return v === inputRoot || v === path.join(inputRoot, '.git');
+      });
+
+      await backup.execute({
+        name: 'backup',
+        args: [inputRoot, outputRoot],
+        options: { filter: '', clean: true },
+        startTime: Date.now()
+      });
+
+      expect(utils.mkdirSync).toHaveBeenCalledWith(
+        path.join(outputRoot, path.basename(inputRoot))
+      );
+    });
+
+    it('filter 应按包名正则过滤（真实 toPatterns）', async () => {
+      vi.mocked(utils.getGroupPackages).mockReturnValue([
+        { ...pkgA, dir: '/ws/p1', name: '@scope/keep' },
+        {
+          dir: '/ws/p2',
+          name: '@scope/skip',
+          manifest: { name: '@scope/skip', version: '0.0.0' },
+          children: []
+        }
+      ]);
+
+      await backup.execute({
+        name: 'backup',
+        args: ['/ws', '/out'],
+        options: { filter: '^@scope/keep$', clean: true },
+        startTime: Date.now()
+      });
+
+      expect(utils.pullCurrentBranch).toHaveBeenCalledTimes(1);
+      expect(utils.pullCurrentBranch).toHaveBeenCalledWith(
+        true,
+        '/ws/p1',
+        expect.any(Boolean)
+      );
+    });
+
+    it('clean=true 时应跳过 node_modules 与 .git', async () => {
+      vi.mocked(utils.eachDirSync).mockImplementation((_root, cb) => {
+        for (const name of ['node_modules', '.git', 'src']) {
+          (cb as (name: string) => void)(name);
+        }
+      });
+
+      await backup.execute({
+        name: 'backup',
+        args: ['/ws', '/out'],
+        options: { filter: '', clean: true },
+        startTime: Date.now()
+      });
+
+      const copied = vi.mocked(utils.cpSync).mock.calls.map(c => c[0]);
+      expect(copied.some(p => p.endsWith(`${path.sep}node_modules`))).toBe(
+        false
+      );
+      expect(copied.some(p => p.endsWith(`${path.sep}.git`))).toBe(false);
+      expect(copied.some(p => p.endsWith(`${path.sep}src`))).toBe(true);
+    });
+
+    it('无任何备份目标时应 exit(1)', async () => {
+      vi.mocked(utils.getGroupPackages).mockReturnValue([]);
+      vi.mocked(utils.existsSync).mockReturnValue(false);
+
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((code = 1) => {
+          throw new Error(`exit:${code}`);
+        });
+
+      await expect(
+        backup.execute({
+          name: 'backup',
+          args: ['/empty', '/out'],
+          options: { filter: '', clean: true },
+          startTime: Date.now()
+        })
+      ).rejects.toThrow('exit:1');
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(utils.cpSync).not.toHaveBeenCalled();
+      exitSpy.mockRestore();
+    });
+
+    it('pull 失败时不应阻断后续 copy', async () => {
+      vi.mocked(utils.pullCurrentBranch).mockImplementation(() => {
+        throw new Error('pull failed');
+      });
+
+      await backup.execute({
+        name: 'backup',
+        args: ['/ws', '/out'],
+        options: { filter: '', clean: true },
+        startTime: Date.now()
+      });
+
+      expect(utils.cpSync).toHaveBeenCalled();
+    });
+
+    it('clean=false 时应复制 .git，仍跳过 node_modules', async () => {
+      vi.mocked(utils.eachDirSync).mockImplementation((_root, cb) => {
+        for (const name of ['node_modules', '.git', 'src']) {
+          (cb as (name: string) => void)(name);
+        }
+      });
+
+      await backup.execute({
+        name: 'backup',
+        args: ['/ws', '/out'],
+        options: { filter: '', clean: false },
+        startTime: Date.now()
+      });
+
+      const copied = vi.mocked(utils.cpSync).mock.calls.map(c => c[0]);
+      expect(copied.some(p => p.endsWith(`${path.sep}node_modules`))).toBe(
+        false
+      );
+      expect(copied.some(p => p.endsWith(`${path.sep}.git`))).toBe(true);
+      expect(copied.some(p => p.endsWith(`${path.sep}src`))).toBe(true);
+    });
   });
 });

--- a/test/built-in/commands/release.cmd.test.ts
+++ b/test/built-in/commands/release.cmd.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 /**
  * @fileoverview 内置命令 `release` 契约测试
- * @description 对齐 `release.cmd.ts`：multi 与 monorepo 可同次执行；`--check` 策略分支不同。
+ * @description 对齐 `release.cmd.ts`：multi 与 monorepo 可同次执行；`check` 策略分支不同。
  */
 
 import type { Stats } from 'node:fs';
@@ -14,16 +14,13 @@ import { ReleaseCommand } from '../../../src/built-in/commands/release.cmd';
 import type { PackageJson } from '../../../src/utils';
 import * as utils from '../../../src/utils';
 
-vi.mock('inquirer', () => ({
-  default: {
-    prompt: vi.fn()
-  }
-}));
+const mockPrompt = vi.fn();
 
 vi.mock('../../../src/utils', async importOriginal => {
   const actual = await importOriginal<typeof import('../../../src/utils')>();
   return {
     ...actual,
+    getInquirer: vi.fn(async () => ({ prompt: mockPrompt })),
     getGroupPackages: vi.fn(),
     getUnCommittedFiles: vi.fn(),
     readJsonSync: vi.fn(),
@@ -60,10 +57,10 @@ const defaultOptions = {
 describe('ReleaseCommand', () => {
   let release: ReleaseCommand;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     release = new ReleaseCommand(new Command('release'), []);
-    const { default: inquirer } = await import('inquirer');
-    vi.mocked(inquirer.prompt).mockResolvedValue({ selecteds: ['pkg-one'] });
+    mockPrompt.mockReset();
+    mockPrompt.mockResolvedValue({ selecteds: ['pkg-one'] });
     vi.mocked(utils.getGroupPackages).mockReturnValue([
       multiPkg({
         dir: path.join(process.cwd(), 'packages/one'),
@@ -106,12 +103,15 @@ describe('ReleaseCommand', () => {
         'force',
         'push'
       ]);
-      expect(args.options?.find(o => o.name === 'check')?.defaultValue).toBe(
-        true
-      );
-      expect(args.options?.find(o => o.name === 'push')?.defaultValue).toBe(
-        true
-      );
+      expect(args.options?.find(o => o.name === 'check')).toMatchObject({
+        defaultValue: true,
+        invert: true
+      });
+      expect(args.options?.find(o => o.name === 'push')).toMatchObject({
+        defaultValue: true,
+        invert: true
+      });
+      expect(args.options?.find(o => o.name === 'type')?.flagValue).toBe(true);
     });
   });
 
@@ -144,8 +144,7 @@ describe('ReleaseCommand', () => {
     });
 
     it('用户未勾选任何包时不应写 manifest', async () => {
-      const { default: inquirer } = await import('inquirer');
-      vi.mocked(inquirer.prompt).mockResolvedValue({ selecteds: [] });
+      mockPrompt.mockResolvedValue({ selecteds: [] });
 
       await release.execute({
         name: 'release',
@@ -174,12 +173,12 @@ describe('ReleaseCommand', () => {
       });
 
       expect(utils.writeJsonSync).not.toHaveBeenCalled();
+      expect(mockPrompt).not.toHaveBeenCalled();
     });
 
     it('multi + check + 用户 abort 时不应写 manifest', async () => {
       vi.mocked(utils.getUnCommittedFiles).mockReturnValue(['M  x.ts']);
-      const { default: inquirer } = await import('inquirer');
-      vi.mocked(inquirer.prompt).mockResolvedValueOnce({ select: 'abort' });
+      mockPrompt.mockResolvedValueOnce({ select: 'abort' });
 
       await release.execute({
         name: 'release',
@@ -208,8 +207,7 @@ describe('ReleaseCommand', () => {
     });
 
     it('多包时应联动依赖版本并保留 workspace:', async () => {
-      const { default: inquirer } = await import('inquirer');
-      vi.mocked(inquirer.prompt).mockResolvedValue({
+      mockPrompt.mockResolvedValue({
         selecteds: ['pkg-a', 'pkg-b']
       });
       vi.mocked(utils.getGroupPackages).mockReturnValue([
@@ -282,6 +280,62 @@ describe('ReleaseCommand', () => {
 
       expect(utils.writeJsonSync).toHaveBeenCalled();
       expect(utils.commitGit).not.toHaveBeenCalled();
+    });
+
+    it('multi 与 monorepo 同次执行时应分别写回', async () => {
+      const monoRoot = path.resolve('/repo/root');
+      const childDir = path.resolve('/repo/packages/one');
+
+      vi.mocked(utils.getGroupPackages).mockReturnValue([
+        multiPkg({
+          dir: path.resolve('/repo/packages/multi'),
+          name: 'pkg-multi',
+          manifest: { name: 'pkg-multi', private: false, version: '2.0.0' }
+        }),
+        {
+          dir: monoRoot,
+          name: 'mono-root',
+          manifest: {
+            name: 'mono-root',
+            version: '1.0.0',
+            private: true
+          },
+          children: [
+            multiPkg({
+              dir: childDir,
+              name: 'pkg-mono-child',
+              manifest: {
+                name: 'pkg-mono-child',
+                private: false,
+                version: '1.0.0'
+              }
+            })
+          ]
+        }
+      ]);
+      mockPrompt
+        .mockResolvedValueOnce({ selecteds: ['pkg-multi'] })
+        .mockResolvedValueOnce({ selecteds: ['pkg-mono-child'] });
+      vi.mocked(utils.readJsonSync).mockImplementation((p: unknown) => {
+        const v = String(p).replace(/\\/g, '/');
+        if (v.includes('pkg-multi')) {
+          return { name: 'pkg-multi', version: '2.0.0' };
+        }
+        if (v.includes('pkg-mono-child')) {
+          return { name: 'pkg-mono-child', version: '1.0.0' };
+        }
+        return { name: 'mono-root', version: '1.0.0' };
+      });
+
+      await release.execute({
+        name: 'release',
+        args: ['.'],
+        options: { ...defaultOptions, force: true, type: 'patch' },
+        startTime: Date.now()
+      });
+
+      expect(utils.writeJsonSync.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(utils.installPnpm).toHaveBeenCalled();
     });
   });
 });

--- a/test/built-in/commands/upgrade.cmd.test.ts
+++ b/test/built-in/commands/upgrade.cmd.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 /**
  * @fileoverview 内置命令 `upgrade` 契约测试
- * @description 对齐 `upgrade.cmd.ts`：先多选依赖再查 registry；multi/mono 互斥。
+ * @description 对齐 `upgrade.cmd.ts`：先 checkbox 再查 registry；写回后 install/commit/push。
  */
 
 import path from 'node:path';
@@ -10,6 +10,7 @@ import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UpgradeCommand } from '../../../src/built-in/commands/upgrade.cmd';
+import type { PackageJson } from '../../../src/utils';
 import * as utils from '../../../src/utils';
 
 vi.mock('../../../src/utils', async importOriginal => {
@@ -18,6 +19,9 @@ vi.mock('../../../src/utils', async importOriginal => {
     ...actual,
     getGroupPackages: vi.fn(),
     execSync: vi.fn(),
+    readJsonSync: vi.fn(),
+    writeJsonSync: vi.fn(),
+    readPnpmCatalogs: vi.fn(),
     checkboxInquirer: vi.fn(),
     confirmInquirer: vi.fn(),
     inputInquirer: vi.fn(),
@@ -37,6 +41,7 @@ function multiPkg(overrides: {
     version: string;
     scope?: string;
     dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
   };
 }) {
   return {
@@ -54,6 +59,35 @@ const defaultOptions = {
   push: false
 } as const;
 
+const multiLodash = () =>
+  multiPkg({
+    dir: '/ws/p1',
+    name: 'pkg-one',
+    manifest: {
+      name: 'pkg-one',
+      version: '1.0.0',
+      scope: '@org/',
+      dependencies: { lodash: '^4.17.0' }
+    }
+  });
+
+/** 无 scope 字段，写回时目标版本为 registry 解析值而非 `*` */
+const multiLodashPlain = () =>
+  multiPkg({
+    dir: '/ws/p1',
+    name: 'pkg-one',
+    manifest: {
+      name: 'pkg-one',
+      version: '1.0.0',
+      dependencies: { lodash: '^4.17.0' }
+    }
+  });
+
+const pkgDir = path.join('/ws/p1');
+const pkgJsonPath = path.join(pkgDir, 'package.json');
+
+const norm = (p: unknown) => String(p).replace(/\\/g, '/');
+
 describe('UpgradeCommand', () => {
   let upgrade: UpgradeCommand;
 
@@ -61,9 +95,12 @@ describe('UpgradeCommand', () => {
     upgrade = new UpgradeCommand(new Command('upgrade'), []);
     vi.mocked(utils.getGroupPackages).mockReturnValue([]);
     vi.mocked(utils.execSync).mockReturnValue('');
+    vi.mocked(utils.readPnpmCatalogs).mockReturnValue({});
     vi.mocked(utils.checkboxInquirer).mockResolvedValue([]);
     vi.mocked(utils.confirmInquirer).mockResolvedValue(false);
     vi.mocked(utils.inputInquirer).mockResolvedValue('');
+    vi.mocked(utils.readJsonSync).mockReturnValue(null);
+    vi.mocked(utils.writeJsonSync).mockImplementation(() => {});
     vi.mocked(utils.installPnpm).mockImplementation(() => {});
     vi.mocked(utils.addGit).mockImplementation(() => {});
     vi.mocked(utils.commitGit).mockImplementation(() => {});
@@ -111,11 +148,7 @@ describe('UpgradeCommand', () => {
 
     it('multi 与 monorepo 同时存在时应 exit(1)', async () => {
       vi.mocked(utils.getGroupPackages).mockReturnValue([
-        multiPkg({
-          dir: '/ws/a',
-          name: 'pkg-a',
-          manifest: { name: 'pkg-a', version: '1.0.0', scope: '@s/' }
-        }),
+        multiLodash(),
         {
           dir: '/repo/root',
           name: 'mono',
@@ -156,20 +189,8 @@ describe('UpgradeCommand', () => {
   });
 
   describe('multi 独立包', () => {
-    const multiWithLodash = () =>
-      multiPkg({
-        dir: '/ws/p1',
-        name: 'pkg-one',
-        manifest: {
-          name: 'pkg-one',
-          version: '1.0.0',
-          scope: '@org/',
-          dependencies: { lodash: '^4.17.0' }
-        }
-      });
-
-    it('应先多选依赖再对选中项 pnpm info', async () => {
-      vi.mocked(utils.getGroupPackages).mockReturnValue([multiWithLodash()]);
+    it('应先 checkbox 再对选中项 pnpm info', async () => {
+      vi.mocked(utils.getGroupPackages).mockReturnValue([multiLodash()]);
       vi.mocked(utils.checkboxInquirer).mockResolvedValue(['lodash']);
       vi.mocked(utils.execSync).mockImplementation((cmd: string) => {
         if (cmd.includes('pnpm info')) {
@@ -196,7 +217,7 @@ describe('UpgradeCommand', () => {
     });
 
     it('用户未勾选时不应查询 registry', async () => {
-      vi.mocked(utils.getGroupPackages).mockReturnValue([multiWithLodash()]);
+      vi.mocked(utils.getGroupPackages).mockReturnValue([multiLodash()]);
       vi.mocked(utils.checkboxInquirer).mockResolvedValue([]);
 
       await upgrade.execute({
@@ -276,34 +297,163 @@ describe('UpgradeCommand', () => {
       expect(utils.checkboxInquirer).not.toHaveBeenCalled();
       expect(utils.execSync).not.toHaveBeenCalled();
     });
+
+    it('精确版本已满足 registry 时不应进入确认写回', async () => {
+      vi.mocked(utils.getGroupPackages).mockReturnValue([
+        multiPkg({
+          dir: '/ws/p1',
+          name: 'pkg-one',
+          manifest: {
+            name: 'pkg-one',
+            version: '1.0.0',
+            dependencies: { lodash: '4.17.21' }
+          }
+        })
+      ]);
+      vi.mocked(utils.checkboxInquirer).mockResolvedValue(['lodash']);
+      vi.mocked(utils.execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes('pnpm info')) {
+          return JSON.stringify({ name: 'lodash', version: '4.17.21' });
+        }
+        return '';
+      });
+
+      await upgrade.execute({
+        name: 'upgrade',
+        args: ['.'],
+        options: { ...defaultOptions },
+        startTime: Date.now()
+      });
+
+      expect(utils.writeJsonSync).not.toHaveBeenCalled();
+    });
+
+    it('force 且确认版本时应写回、install 并提交', async () => {
+      vi.mocked(utils.getGroupPackages).mockReturnValue([multiLodashPlain()]);
+      vi.mocked(utils.checkboxInquirer).mockResolvedValue(['lodash']);
+      vi.mocked(utils.confirmInquirer).mockResolvedValue(true);
+      vi.mocked(utils.readJsonSync).mockImplementation((p: unknown) => {
+        if (norm(p).endsWith('/ws/p1/package.json')) {
+          return {
+            name: 'pkg-one',
+            version: '1.0.0',
+            dependencies: { lodash: '^4.17.0' }
+          } satisfies PackageJson;
+        }
+        return null;
+      });
+      vi.mocked(utils.getUnCommittedFiles).mockReturnValue(['package.json']);
+      vi.mocked(utils.execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes('pnpm info')) {
+          return JSON.stringify({ name: 'lodash', version: '4.17.21' });
+        }
+        return '';
+      });
+
+      await upgrade.execute({
+        name: 'upgrade',
+        args: ['.'],
+        options: { ...defaultOptions, force: true },
+        startTime: Date.now()
+      });
+
+      expect(utils.writeJsonSync).toHaveBeenCalledWith(
+        pkgJsonPath,
+        expect.objectContaining({
+          dependencies: { lodash: '4.17.21' }
+        })
+      );
+      expect(utils.installPnpm).toHaveBeenCalledWith(pkgDir);
+      expect(utils.addGit).toHaveBeenCalledWith(pkgDir);
+      expect(utils.commitGit).toHaveBeenCalled();
+      expect(utils.pushGit).not.toHaveBeenCalled();
+    });
+
+    it('用户拒绝提交时不应 commit', async () => {
+      vi.mocked(utils.getGroupPackages).mockReturnValue([multiLodashPlain()]);
+      vi.mocked(utils.checkboxInquirer).mockResolvedValue(['lodash']);
+      vi.mocked(utils.confirmInquirer).mockImplementation(async msg => {
+        if (String(msg).includes('Continue commit')) return false;
+        return true;
+      });
+      vi.mocked(utils.readJsonSync).mockReturnValue({
+        name: 'pkg-one',
+        version: '1.0.0',
+        dependencies: { lodash: '^4.17.0' }
+      });
+      vi.mocked(utils.execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes('pnpm info')) {
+          return JSON.stringify({ name: 'lodash', version: '4.17.21' });
+        }
+        return '';
+      });
+
+      await upgrade.execute({
+        name: 'upgrade',
+        args: ['.'],
+        options: { ...defaultOptions },
+        startTime: Date.now()
+      });
+
+      expect(utils.writeJsonSync).toHaveBeenCalled();
+      expect(utils.installPnpm).toHaveBeenCalled();
+      expect(utils.commitGit).not.toHaveBeenCalled();
+    });
+
+    it('force + push 且有未提交变更时应 push', async () => {
+      vi.mocked(utils.getGroupPackages).mockReturnValue([multiLodashPlain()]);
+      vi.mocked(utils.checkboxInquirer).mockResolvedValue(['lodash']);
+      vi.mocked(utils.confirmInquirer).mockResolvedValue(true);
+      vi.mocked(utils.readJsonSync).mockReturnValue({
+        name: 'pkg-one',
+        version: '1.0.0',
+        dependencies: { lodash: '^4.17.0' }
+      });
+      vi.mocked(utils.getUnCommittedFiles).mockReturnValue(['package.json']);
+      vi.mocked(utils.execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes('pnpm info')) {
+          return JSON.stringify({ name: 'lodash', version: '4.17.21' });
+        }
+        return '';
+      });
+
+      await upgrade.execute({
+        name: 'upgrade',
+        args: ['.'],
+        options: { ...defaultOptions, force: true, push: true },
+        startTime: Date.now()
+      });
+
+      expect(utils.pushGit).toHaveBeenCalledWith(pkgDir);
+    });
   });
 
   describe('monorepo', () => {
-    it('应先 pnpm info 再 pnpm search scope 私有包', async () => {
-      vi.mocked(utils.getGroupPackages).mockReturnValue([
-        {
-          dir: '/repo/root',
-          name: 'mono-root',
+    const monoRoot = () => ({
+      dir: '/repo/root',
+      name: 'mono-root',
+      manifest: {
+        name: 'mono-root',
+        version: '1.0.0',
+        private: true,
+        scope: '@myorg/',
+        dependencies: { 'external-pkg': '^1.0.0' }
+      },
+      children: [
+        multiPkg({
+          dir: '/repo/packages/app',
+          name: '@myorg/app',
           manifest: {
-            name: 'mono-root',
+            name: '@myorg/app',
             version: '1.0.0',
-            private: true,
-            scope: '@myorg/',
-            dependencies: { 'external-pkg': '^1.0.0' }
-          },
-          children: [
-            multiPkg({
-              dir: '/repo/packages/app',
-              name: '@myorg/app',
-              manifest: {
-                name: '@myorg/app',
-                version: '1.0.0',
-                dependencies: { 'external-pkg': '1.0.0' }
-              }
-            })
-          ]
-        }
-      ]);
+            dependencies: { 'external-pkg': '1.0.0' }
+          }
+        })
+      ]
+    });
+
+    it('应先 checkbox、pnpm info，再 pnpm search scope 私有包', async () => {
+      vi.mocked(utils.getGroupPackages).mockReturnValue([monoRoot()]);
       vi.mocked(utils.checkboxInquirer).mockResolvedValue(['external-pkg']);
       const calls: string[] = [];
       vi.mocked(utils.execSync).mockImplementation((cmd: string) => {
@@ -328,6 +478,55 @@ describe('UpgradeCommand', () => {
       expect(calls.some(c => c.includes('pnpm search'))).toBe(true);
       expect(calls.findIndex(c => c.includes('pnpm info'))).toBeLessThan(
         calls.findIndex(c => c.includes('pnpm search'))
+      );
+      expect(utils.execSync).toHaveBeenCalledWith(
+        expect.stringContaining('pnpm search'),
+        expect.objectContaining({ cwd: '/repo/root' })
+      );
+    });
+
+    it('force 写回后应在 monorepo 根 install 并提交', async () => {
+      vi.mocked(utils.getGroupPackages).mockReturnValue([monoRoot()]);
+      vi.mocked(utils.checkboxInquirer).mockResolvedValue(['external-pkg']);
+      vi.mocked(utils.confirmInquirer).mockResolvedValue(true);
+      vi.mocked(utils.readJsonSync).mockImplementation((p: unknown) => {
+        const v = norm(p);
+        if (v.endsWith('/repo/root/package.json')) {
+          return {
+            name: 'mono-root',
+            version: '1.0.0',
+            dependencies: { 'external-pkg': '^1.0.0' }
+          } satisfies PackageJson;
+        }
+        if (v.endsWith('/repo/packages/app/package.json')) {
+          return {
+            name: '@myorg/app',
+            version: '1.0.0',
+            dependencies: { 'external-pkg': '1.0.0' }
+          } satisfies PackageJson;
+        }
+        return null;
+      });
+      vi.mocked(utils.getUnCommittedFiles).mockReturnValue(['package.json']);
+      vi.mocked(utils.execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes('pnpm info')) {
+          return JSON.stringify({ name: 'external-pkg', version: '1.0.1' });
+        }
+        if (cmd.includes('pnpm search')) return '';
+        return '';
+      });
+
+      await upgrade.execute({
+        name: 'upgrade',
+        args: ['.'],
+        options: { ...defaultOptions, force: true },
+        startTime: Date.now()
+      });
+
+      expect(utils.installPnpm).toHaveBeenCalledWith('/repo/root');
+      expect(utils.commitGit).toHaveBeenCalledWith(
+        expect.anything(),
+        '/repo/root'
       );
     });
   });

--- a/test/fixtures/empty-cli-cwd/hello.cmd.ts
+++ b/test/fixtures/empty-cli-cwd/hello.cmd.ts
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview 简单的 Hello World 命令示例
+ * @description 演示如何创建一个基本的命令
+ */
+
+import { BaseCommand, type CommandContext } from '@jshow/cli';
+
+/**
+ * 示例：最小 `hello` 命令，演示生命周期钩子。
+ * @example
+ * ```bash
+ * jshow hello
+ * jshow hi
+ * ```
+ */
+export default class HelloCommand extends BaseCommand {
+  static key = 'hello';
+  static force = false;
+
+  /**
+   * 命令参数配置。
+   * @returns 命令元信息与示例
+   */
+  public get args() {
+    return {
+      name: 'hello',
+      description: '输出 Hello World 消息',
+      aliases: ['hi', 'h'],
+      group: 'examples',
+      options: [],
+      examples: ['jshow hello', 'jshow hi']
+    };
+  }
+
+  /**
+   * 执行前钩子（示例）。
+   * @param context - 命令上下文
+   * @returns void
+   */
+  public async beforeExecute(context: CommandContext): Promise<void> {
+    console.log('准备执行 hello 命令...');
+  }
+
+  /**
+   * 命令主体逻辑（示例）。
+   * @returns void
+   */
+  public async execute(context: CommandContext): Promise<void> {
+    console.log('Hello, World!');
+  }
+
+  /**
+   * 执行后钩子（示例）。
+   * @param context - 命令上下文
+   * @returns void
+   */
+  public async afterExecute(context: CommandContext): Promise<void> {
+    const duration = Date.now() - context.startTime;
+    console.log(`命令执行完成，耗时: ${duration}ms`);
+  }
+}


### PR DESCRIPTION
- Realign backup, release, and upgrade tests with current CLI contracts
- Fix CommandOption.invert JSDoc and README dev notes for discovery/invert
- Add JSDoc on built-in commands and cli; add hello.cmd discovery fixture