### PR TITLE
refactor: unify release inquirer helpers and align tests

### DIFF
--- a/src/built-in/commands/backup.cmd.ts
+++ b/src/built-in/commands/backup.cmd.ts
@@ -276,7 +276,11 @@ export class BackupCommand extends BaseCommand<BackupOptions> {
     logger.info('Start', {
       cwd,
       input: path.relative(cwd, inputRoot),
-      output: path.relative(cwd, outputRoot)
+      output: path.relative(cwd, outputRoot),
+      options: {
+        clean,
+        filter
+      }
     });
     logger.empty();
 

--- a/src/built-in/commands/release.cmd.ts
+++ b/src/built-in/commands/release.cmd.ts
@@ -18,11 +18,14 @@ import {
 import { logger as loggerCli } from '../../logger';
 import {
   addGit,
+  checkboxInquirer,
   commitGit,
+  confirmInquirer,
   execSync,
   getGroupPackages,
-  getInquirer,
   getUnCommittedFiles,
+  inputInquirer,
+  type InquirerChoices,
   installPnpm,
   PACKAGE_DEPENDENCY_KEYS,
   PACKAGE_JSON_FILE,
@@ -33,6 +36,7 @@ import {
   pushGit,
   readJsonSync,
   resetGit,
+  selectInquirer,
   separateGroupPackages,
   statSync,
   writeJsonSync
@@ -118,26 +122,26 @@ const checkPackageUncommittedForMulti = async (
     indexs.push(i);
   }
 
-  const inquirer = await getInquirer();
-  const { select } = await inquirer.prompt<{ select: string }>({
-    type: 'rawlist',
-    name: 'select',
-    message: [
-      'The packages are not committed, how to do?',
-      ...indexs.map(i => {
-        const pkg = packages[i];
-        return `- ${pkg.name}: ${pkg.manifest.version}`;
-      }),
-      ''
-    ].join('\n'),
-    choices: [
-      { name: 'Skip these packages', value: 'skip' },
-      { name: 'Reset the unsubmitted changes', value: 'reset' },
-      { name: 'Ignore', value: 'ignore' },
-      { name: 'Abort', value: 'abort' }
-    ],
-    default: 'skip'
-  });
+  let select = 'ignore';
+  if (indexs.length > 0) {
+    select = await selectInquirer(
+      [
+        'The packages are not committed, how to do?',
+        ...indexs.map(i => {
+          const pkg = packages[i];
+          return `- ${pkg.name}: ${pkg.manifest.version}`;
+        }),
+        ''
+      ].join('\n'),
+      [
+        { name: 'Skip these packages', value: 'skip' },
+        { name: 'Reset the unsubmitted changes', value: 'reset' },
+        { name: 'Ignore', value: 'ignore' },
+        { name: 'Abort', value: 'abort' }
+      ],
+      'skip'
+    );
+  }
 
   switch (select) {
     case 'skip':
@@ -172,15 +176,12 @@ const filterReleasePackages = async (list: PackageInfo[]) => {
   const packages = list.filter(v => !v.manifest.private);
   if (packages.length < 1) return [];
 
-  const inquirer = await getInquirer();
-  const { selecteds } = await inquirer.prompt<{ selecteds: string[] }>({
-    type: 'checkbox',
-    name: 'selecteds',
-    message: 'Select the packages to release',
-    choices: packages.map(o => o.name)
-  });
+  const selects = await checkboxInquirer(
+    'Select the packages to release',
+    packages.map(o => o.name)
+  );
 
-  return packages.filter(o => selecteds.includes(o.name));
+  return packages.filter(o => selects.includes(o.name));
 };
 
 /**
@@ -208,43 +209,34 @@ const askForNextVersion = async (
     if (nextVersion) return nextVersion;
   }
 
-  const inquirer = await getInquirer();
-  nextVersion = (
-    await inquirer.prompt<{ version: string }>({
-      type: 'rawlist',
-      name: 'version',
-      message: `Select release type for ${packageName}`,
-      choices: releaseTypes
-        .map(type => {
-          // 列表展示 bump 预览，便于用户对比当前版与候选下一版
-          const value = semver.inc(currVersion, type, preReleaseIdentifier);
+  nextVersion = await selectInquirer(
+    `Select release type for ${packageName}`,
+    releaseTypes
+      .map(type => {
+        // 列表展示 bump 预览，便于用户对比当前版与候选下一版
+        const value = semver.inc(currVersion, type, preReleaseIdentifier);
 
-          return {
-            name: `${type} (${currVersion} ==> ${value})`,
-            value
-          };
-        })
-        .concat({
-          name: 'custom',
-          value: 'custom'
-        }),
-      default: semver.inc(
-        currVersion,
-        preReleaseIdentifier ? 'prepatch' : 'patch',
-        preReleaseIdentifier
-      )
-    })
-  ).version;
+        return {
+          name: `${type} (${currVersion} ==> ${value})`,
+          value
+        };
+      })
+      .concat({
+        name: 'custom',
+        value: 'custom'
+      }) as InquirerChoices,
+    semver.inc(
+      currVersion,
+      preReleaseIdentifier ? 'prepatch' : 'patch',
+      preReleaseIdentifier
+    ) || void 0
+  );
 
   if (nextVersion === 'custom') {
-    nextVersion = (
-      await inquirer.prompt<{ version: string }>({
-        type: 'input',
-        name: 'version',
-        message: `Enter the custom version for ${packageName}`,
-        default: semver.inc(currVersion, 'patch', preReleaseIdentifier)
-      })
-    ).version;
+    nextVersion = await inputInquirer(
+      `Enter the custom version for ${packageName}`,
+      semver.inc(currVersion, 'patch', preReleaseIdentifier) || void 0
+    );
 
     if (!nextVersion) {
       log.error(`No version input`);
@@ -384,20 +376,15 @@ const releasePackageForMonrepo = async (
   push: boolean
 ) => {
   if (!force) {
-    const inquirer = await getInquirer();
-    const yes = (
-      await inquirer.prompt({
-        type: 'confirm',
-        name: 'value',
-        message: [
-          'Confirm:',
-          ...Object.entries(versions).map(
-            ([name, ver]) => `${name}: ${ver.old} => ${ver.new}`
-          ),
-          ''
-        ].join('\n')
-      })
-    ).value;
+    const yes = await confirmInquirer(
+      [
+        'Confirm:',
+        ...Object.entries(versions).map(
+          ([name, ver]) => `${name}: ${ver.old} => ${ver.new}`
+        ),
+        ''
+      ].join('\n')
+    );
     if (!yes) return;
 
     log.empty();
@@ -454,19 +441,17 @@ const releasePackageForMulti = async (
       versions[key] = data[key];
     }
   } else {
-    const inquirer = await getInquirer();
-    const { selecteds } = await inquirer.prompt<{ selecteds: string[] }>({
-      type: 'checkbox',
-      name: 'selecteds',
-      message: 'Select the package to release',
-      choices: Object.entries(data).map(([name, ver]) => ({
+    const selecteds = await checkboxInquirer(
+      'Select the package to release',
+      Object.entries(data).map(([name, ver]) => ({
         name: `${name}: ${ver.old} => ${ver.new}`,
         value: name
-      })),
-      default: Object.keys(data)
-    });
-
-    if (selecteds.length < 1) return;
+      }))
+    );
+    if (selecteds.length < 1) {
+      log.warn('No packages to release');
+      return false;
+    }
 
     for (const key of selecteds) {
       versions[key] = data[key];
@@ -700,7 +685,8 @@ export class ReleaseCommand extends BaseCommand<ReleaseOptions> {
     const cwd = process.cwd();
     logger.info('Start', {
       cwd,
-      input: path.relative(cwd, inputRoot)
+      input: path.relative(cwd, inputRoot),
+      options
     });
     logger.empty();
 

--- a/src/built-in/commands/upgrade.cmd.ts
+++ b/src/built-in/commands/upgrade.cmd.ts
@@ -1039,7 +1039,11 @@ export class UpgradeCommand extends BaseCommand<UpgradeOptions> {
     const cwd = process.cwd();
     logger.info('Start', {
       cwd,
-      input: path.relative(cwd, inputRoot)
+      input: path.relative(cwd, inputRoot),
+      options: {
+        ignore,
+        ...options
+      }
     });
     logger.empty();
 

--- a/test/built-in/commands/release.cmd.test.ts
+++ b/test/built-in/commands/release.cmd.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 /**
  * @fileoverview 内置命令 `release` 契约测试
- * @description 对齐 `release.cmd.ts`：multi 与 monorepo 可同次执行；`check` 策略分支不同。
+ * @description 对齐 `release.cmd.ts`：inquirer 封装；multi 与 monorepo 可同次执行。
  */
 
 import type { Stats } from 'node:fs';
@@ -14,13 +14,10 @@ import { ReleaseCommand } from '../../../src/built-in/commands/release.cmd';
 import type { PackageJson } from '../../../src/utils';
 import * as utils from '../../../src/utils';
 
-const mockPrompt = vi.fn();
-
 vi.mock('../../../src/utils', async importOriginal => {
   const actual = await importOriginal<typeof import('../../../src/utils')>();
   return {
     ...actual,
-    getInquirer: vi.fn(async () => ({ prompt: mockPrompt })),
     getGroupPackages: vi.fn(),
     getUnCommittedFiles: vi.fn(),
     readJsonSync: vi.fn(),
@@ -31,7 +28,11 @@ vi.mock('../../../src/utils', async importOriginal => {
     addGit: vi.fn(),
     commitGit: vi.fn(),
     pushGit: vi.fn(),
-    resetGit: vi.fn()
+    resetGit: vi.fn(),
+    checkboxInquirer: vi.fn(),
+    selectInquirer: vi.fn(),
+    confirmInquirer: vi.fn(),
+    inputInquirer: vi.fn()
   };
 });
 
@@ -59,8 +60,6 @@ describe('ReleaseCommand', () => {
 
   beforeEach(() => {
     release = new ReleaseCommand(new Command('release'), []);
-    mockPrompt.mockReset();
-    mockPrompt.mockResolvedValue({ selecteds: ['pkg-one'] });
     vi.mocked(utils.getGroupPackages).mockReturnValue([
       multiPkg({
         dir: path.join(process.cwd(), 'packages/one'),
@@ -83,6 +82,10 @@ describe('ReleaseCommand', () => {
     vi.mocked(utils.commitGit).mockImplementation(() => {});
     vi.mocked(utils.pushGit).mockImplementation(() => {});
     vi.mocked(utils.resetGit).mockImplementation(() => {});
+    vi.mocked(utils.checkboxInquirer).mockResolvedValue(['pkg-one']);
+    vi.mocked(utils.selectInquirer).mockResolvedValue('patch');
+    vi.mocked(utils.confirmInquirer).mockResolvedValue(true);
+    vi.mocked(utils.inputInquirer).mockResolvedValue('');
   });
 
   afterEach(() => vi.clearAllMocks());
@@ -141,10 +144,11 @@ describe('ReleaseCommand', () => {
       });
 
       expect(utils.writeJsonSync).not.toHaveBeenCalled();
+      expect(utils.checkboxInquirer).not.toHaveBeenCalled();
     });
 
     it('用户未勾选任何包时不应写 manifest', async () => {
-      mockPrompt.mockResolvedValue({ selecteds: [] });
+      vi.mocked(utils.checkboxInquirer).mockResolvedValue([]);
 
       await release.execute({
         name: 'release',
@@ -173,12 +177,12 @@ describe('ReleaseCommand', () => {
       });
 
       expect(utils.writeJsonSync).not.toHaveBeenCalled();
-      expect(mockPrompt).not.toHaveBeenCalled();
+      expect(utils.checkboxInquirer).not.toHaveBeenCalled();
     });
 
     it('multi + check + 用户 abort 时不应写 manifest', async () => {
       vi.mocked(utils.getUnCommittedFiles).mockReturnValue(['M  x.ts']);
-      mockPrompt.mockResolvedValueOnce({ select: 'abort' });
+      vi.mocked(utils.selectInquirer).mockResolvedValue('abort');
 
       await release.execute({
         name: 'release',
@@ -187,7 +191,22 @@ describe('ReleaseCommand', () => {
         startTime: Date.now()
       });
 
+      expect(utils.selectInquirer).toHaveBeenCalled();
       expect(utils.writeJsonSync).not.toHaveBeenCalled();
+    });
+
+    it('multi + check + 全部干净时不弹出未提交提示', async () => {
+      vi.mocked(utils.getUnCommittedFiles).mockReturnValue([]);
+
+      await release.execute({
+        name: 'release',
+        args: ['.'],
+        options: { ...defaultOptions, check: true, force: true, type: 'patch' },
+        startTime: Date.now()
+      });
+
+      expect(utils.selectInquirer).not.toHaveBeenCalled();
+      expect(utils.writeJsonSync).toHaveBeenCalled();
     });
   });
 
@@ -200,6 +219,10 @@ describe('ReleaseCommand', () => {
         startTime: Date.now()
       });
 
+      expect(utils.checkboxInquirer).toHaveBeenCalledWith(
+        'Select the packages to release',
+        ['pkg-one']
+      );
       expect(utils.writeJsonSync).toHaveBeenCalled();
       const written = vi.mocked(utils.writeJsonSync).mock
         .calls[0][1] as PackageJson;
@@ -207,9 +230,7 @@ describe('ReleaseCommand', () => {
     });
 
     it('多包时应联动依赖版本并保留 workspace:', async () => {
-      mockPrompt.mockResolvedValue({
-        selecteds: ['pkg-a', 'pkg-b']
-      });
+      vi.mocked(utils.checkboxInquirer).mockResolvedValue(['pkg-a', 'pkg-b']);
       vi.mocked(utils.getGroupPackages).mockReturnValue([
         multiPkg({
           dir: '/repo/packages/a',
@@ -313,9 +334,9 @@ describe('ReleaseCommand', () => {
           ]
         }
       ]);
-      mockPrompt
-        .mockResolvedValueOnce({ selecteds: ['pkg-multi'] })
-        .mockResolvedValueOnce({ selecteds: ['pkg-mono-child'] });
+      vi.mocked(utils.checkboxInquirer)
+        .mockResolvedValueOnce(['pkg-multi'])
+        .mockResolvedValueOnce(['pkg-mono-child']);
       vi.mocked(utils.readJsonSync).mockImplementation((p: unknown) => {
         const v = String(p).replace(/\\/g, '/');
         if (v.includes('pkg-multi')) {


### PR DESCRIPTION
- Replace getInquirer prompts with checkbox/select/confirm/input in release
- Only prompt on dirty multi packages when check is enabled; log options on start
- Rewrite release.cmd.test.ts to mock inquirer utils