### PR TITLE
feat: add built-in publish command and enhance release report

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ See [`examples/README.md`](./examples/README.md) for detailed usage instructions
 
 Registered automatically by `initBuiltIn(CommandProgram)` before `CommandProgram.run()`:
 
-- **`release`**: interactive flow to pick public packages, bump versions (`semver`), run `pnpm install`, `git add` / `git commit -F`, and optional `git push` (multi-repo and monorepo can run in one invocation). See [`docs/release.md`](./docs/release.md).
+- **`release`**: interactive flow to pick public packages, bump versions (`semver`), run `pnpm install`, `git add` / `git commit -F`, and optional `git push` (multi-repo and monorepo can run in one invocation). End-of-run **Report** table includes `status` and `count` (selected packages). See [`docs/release.md`](./docs/release.md).
+- **`publish`**: validates a single package, strips `devDependencies`, resolves `workspace:` / `catalog:` versions for publish, and runs `npm publish` (CI-oriented; leaves the formatted `package.json` on disk). See [`docs/publish.md`](./docs/publish.md).
 - **`backup`**: resolves packages via `getGroupPackages` (falls back to `.git` repo scan), optionally `git pull` per package, then copies each package’s top-level entries to an output folder (skips `node_modules`; `-c` excludes `.git`). See [`docs/backup.md`](./docs/backup.md).
 - **`upgrade`**: scans workspace dependencies, lets you multi-select dependencies to query, fetches registry versions, interactively confirms per-field bumps, writes `package.json`, runs `pnpm install`, and optional Git commit/push (multi-repo vs monorepo cannot be mixed). `--force` skips commit/push prompts. See [`docs/upgrade.md`](./docs/upgrade.md) (`--local` not wired yet).
 
@@ -236,7 +237,7 @@ Imported from `@jshow/cli`, shared with built-in `release` / `backup`:
 | Workspace | `getGroupPackages`, `getWorkspacePackages`, `separateGroupPackages` | Scan monorepo / multi-package roots |
 | FS / process | `existsSync`, `readJsonSync`, `writeJsonSync`, `execSync`, `cpSync`, … | Safe I/O and sync subprocess |
 | Git | `getCurrentBranch`, `pullCurrentBranch`, `getUnCommittedFiles`, `diffGit`, `addGit`, `commitGit`, `pushGit`, … | Release/upgrade/backup Git helpers |
-| pnpm | `installPnpm`, `readPnpmCatalogs`, `PNPM_BUILT_IN_WORKSPACE`, `PNPM_BUILT_IN_CATALOG` | Install deps, catalog read, built-in prefixes |
+| pnpm | `installPnpm`, `readPnpmCatalogs`, `findPnpmWorkspaceRoot`, `PNPM_BUILT_IN_WORKSPACE`, `PNPM_BUILT_IN_CATALOG` | Install deps, catalog read, workspace root lookup, built-in prefixes |
 | Prompts | `confirmInquirer`, `inputInquirer`, `checkboxInquirer`, … | Dynamic inquirer wrappers for CLI |
 | Terminal | `red`, `green`, `yellow` | ANSI color helpers |
 | Regexp | `toRegExp`, `toPatterns` | Comma-separated filters (e.g. `backup -f`, `upgrade -i`) |
@@ -280,7 +281,7 @@ Mounts all commands, enhances help text, then `await program.parseAsync(process.
 
 ### `initBuiltIn`
 
-`initBuiltIn(CommandProgram)` installs default plugins and registers built-in commands (`release`, `backup`, `upgrade`), returning `CommandProgram` for chaining.
+`initBuiltIn(CommandProgram)` installs default plugins and registers built-in commands (`release`, `publish`, `backup`, `upgrade`), returning `CommandProgram` for chaining.
 
 ### CommandArgs
 
@@ -474,7 +475,7 @@ The CLI automatically scans the current working directory and its subdirectories
 │   ├── built-in/       # Default commands/plugins wired by initBuiltIn
 │   └── utils/          # Workspace scan, git, pnpm, fs helpers
 ├── test/               # Vitest specs and fixtures (not published)
-├── docs/               # Built-in command docs (backup / release / upgrade)
+├── docs/               # Built-in command docs (backup / publish / release / upgrade)
 ├── examples/           # Sample .cmd / .plugin files
 ├── scripts/            # Dev helpers (e.g. run-cli-help.mjs)
 ├── dist/               # Vite build output (gitignored)

--- a/README_CN.md
+++ b/README_CN.md
@@ -219,7 +219,8 @@ await initBuiltIn(CommandProgram).run();
 
 由 `initBuiltIn(CommandProgram)` 在 `CommandProgram.run()` 之前默认注册：
 
-- **`release`**：交互选择待发布的非 private 包、`semver` bump、`pnpm install`、`git add` / `git commit -F`、可选 `git push`（多独立仓与 monorepo 可同次执行）。详见 [`docs/release.md`](./docs/release.md)。
+- **`release`**：交互选择待发布的非 private 包、`semver` bump、`pnpm install`、`git add` / `git commit -F`、可选 `git push`（多独立仓与 monorepo 可同次执行）；结束时 **Report** 表含 `status` 与 `count`（实际选中包数）。详见 [`docs/release.md`](./docs/release.md)。
+- **`publish`**：校验并发布**单个** npm 包：移除 `devDependencies`、解析 `workspace:` / `catalog:` 后执行 `npm publish`（面向 CI，保留改写后的 `package.json`）。详见 [`docs/publish.md`](./docs/publish.md)。
 - **`backup`**：用 `getGroupPackages` 解析包（无 manifest 时回退扫描 `.git` 仓），可选 `git pull`，再将包目录一级内容复制到输出目录（默认跳过 `node_modules`，`-c` 可排除 `.git`）。详见 [`docs/backup.md`](./docs/backup.md)。
 - **`upgrade`**：扫描工作区依赖、多选待查询的依赖名后拉取 registry 版本，按 manifest 字段交互确认 bump，写回 `package.json` 并 `pnpm install`，可选 Git 提交与推送（多独立包与 monorepo 不可混扫）。`--force` 跳过提交/推送确认。详见 [`docs/upgrade.md`](./docs/upgrade.md)（`--local` 待接）。
 
@@ -236,7 +237,7 @@ await initBuiltIn(CommandProgram).run();
 | 工作区 | `getGroupPackages`, `getWorkspacePackages`, `separateGroupPackages` | 扫描 monorepo / 多包目录 |
 | 文件系统 | `existsSync`, `readJsonSync`, `writeJsonSync`, `execSync`, `cpSync`, … | 安全读写与同步子进程 |
 | Git | `getCurrentBranch`, `pullCurrentBranch`, `getUnCommittedFiles`, `diffGit`, `addGit`, `commitGit`, `pushGit`, … | 发版/升级/备份常用 Git 封装 |
-| pnpm | `installPnpm`, `readPnpmCatalogs`, `PNPM_BUILT_IN_WORKSPACE`, `PNPM_BUILT_IN_CATALOG` | 安装依赖、catalog 读取、内置前缀常量 |
+| pnpm | `installPnpm`, `readPnpmCatalogs`, `findPnpmWorkspaceRoot`, `PNPM_BUILT_IN_WORKSPACE`, `PNPM_BUILT_IN_CATALOG` | 安装依赖、catalog 读取、向上查找 workspace 根、内置前缀常量 |
 | 交互 | `confirmInquirer`, `inputInquirer`, `checkboxInquirer`, … | 动态加载 inquirer 的 CLI 提示封装 |
 | 终端 | `red`, `green`, `yellow` | ANSI 颜色辅助 |
 | 正则 | `toRegExp`, `toPatterns` | 逗号分隔过滤模式（如 `backup -f`、`upgrade -i`） |
@@ -280,7 +281,7 @@ await initBuiltIn(CommandProgram).run();
 
 ### `initBuiltIn`
 
-`initBuiltIn(CommandProgram)` 安装默认插件并注册内置命令（`release`、`backup`、`upgrade`），返回 `CommandProgram` 以支持链式调用。
+`initBuiltIn(CommandProgram)` 安装默认插件并注册内置命令（`release`、`publish`、`backup`、`upgrade`），返回 `CommandProgram` 以支持链式调用。
 
 
 ### CommandArgs
@@ -475,7 +476,7 @@ CLI 会自动扫描当前工作目录及其子目录，查找所有 `.cmd.ts`、
 │   ├── built-in/       # initBuiltIn 注册的默认命令/插件
 │   └── utils/          # 工作区扫描、git、pnpm、fs 等
 ├── test/               # Vitest 与 fixtures（不参与包发布）
-├── docs/               # 内置命令说明（backup / release / upgrade）
+├── docs/               # 内置命令说明（backup / publish / release / upgrade）
 ├── examples/           # 示例 .cmd / .plugin
 ├── scripts/            # 开发辅助脚本（如 run-cli-help.mjs）
 ├── dist/               # Vite 构建输出（通常 gitignore）

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,0 +1,34 @@
+# publish 命令
+
+实现：`src/built-in/commands/publish.cmd.ts`  
+注册：`src/built-in/commands/index.ts` 的 `BUILT_IN_COMMANDS`（随 `initBuiltIn` 默认加载）。
+
+## 功能
+
+- 在指定目录发布**单个** npm 包（非 private）。
+- 发布前改写 `package.json`：
+  - 移除 `devDependencies`；
+  - 将 `dependencies` / `peerDependencies` / `optionalDependencies` 及 `pnpm.overrides` 中的 `workspace:`、`catalog:` 协议解析为可发布的 semver 字符串。
+- 执行 `npm publish --no-git-checks`；scoped 包（`@scope/name`）自动附加 `--access public`。
+- 面向 CI 场景：改写后的 `package.json` 会保留在磁盘上，不恢复原始内容。
+
+## 命令行
+
+| 项 | 说明 |
+| --- | --- |
+| 位置参数 `input` | 待发布包根目录，默认 `.` |
+
+## 版本解析
+
+1. `findPnpmWorkspaceRoot` 自包目录向上查找 `pnpm-workspace.yaml`（默认最多 3 层）；未找到则以 `input` 为 workspace 根。
+2. `getWorkspacePackages` 收集工作区内包名 → 版本，用于解析 `workspace:` / `workspace:^` / `workspace:~`。
+3. `readPnpmCatalogs` 读取 catalog 映射，用于解析 `catalog:` / `catalog:组名`。
+
+无法解析的 workspace/catalog 依赖会抛错并 `process.exit(1)`。
+
+## 示例
+
+```bash
+jshow publish
+jshow publish ./packages/core
+```

--- a/src/built-in/commands/index.ts
+++ b/src/built-in/commands/index.ts
@@ -6,6 +6,7 @@
 import { type CommandClassType } from '../../command';
 
 import { BackupCommand } from './backup.cmd';
+import { PublishCommand } from './publish.cmd';
 import { ReleaseCommand } from './release.cmd';
 import { UpgradeCommand } from './upgrade.cmd';
 
@@ -15,6 +16,7 @@ import { UpgradeCommand } from './upgrade.cmd';
  */
 export const BUILT_IN_COMMANDS: CommandClassType[] = [
   BackupCommand,
+  PublishCommand,
   ReleaseCommand,
   UpgradeCommand
 ];

--- a/src/built-in/commands/publish.cmd.ts
+++ b/src/built-in/commands/publish.cmd.ts
@@ -1,0 +1,259 @@
+/**
+ * @fileoverview `publish` 内置命令
+ * @description 校验目标包、格式化 manifest（移除 devDependencies、解析 workspace/catalog 版本）并执行 `npm publish`。
+ */
+
+import path from 'node:path';
+
+import {
+  BaseCommand,
+  type CommandArgs,
+  type CommandContext,
+  type CommandOptionsType
+} from '../../command';
+import { logger as loggerCli } from '../../logger';
+import {
+  execSync,
+  existsSync,
+  getWorkspacePackages,
+  PACKAGE_DEPENDENCY_KEYS,
+  PACKAGE_JSON_FILE,
+  PNPM_BUILT_IN_CATALOG,
+  PNPM_BUILT_IN_WORKSPACE,
+  readJsonSync,
+  readPnpmCatalogs,
+  type PackageJson,
+  writeJsonSync,
+  findPnpmWorkspaceRoot
+} from '../../utils';
+
+const logger = loggerCli.fork({ namespace: 'publish' });
+
+/** 参与 workspace/catalog 解析的 manifest 依赖字段（不含 devDependencies）。 */
+const PUBLISH_DEPENDENCY_KEYS = PACKAGE_DEPENDENCY_KEYS.filter(
+  key => key !== 'devDependencies'
+);
+
+/** 发布前解析 workspace / catalog 版本所需的上下文。 */
+interface PublishVersionContext {
+  /** 工作区内包名 → 版本 */
+  versions: Record<string, string>;
+  /** catalog 前缀 → 包名 → 版本 */
+  catalogs: Record<string, Record<string, string>>;
+}
+
+/**
+ * 将 `workspace:` / `catalog:` 协议版本解析为可发布的 semver 字符串。
+ * @param depName - 依赖包名
+ * @param version - manifest 中的版本声明
+ * @param ctx - workspace 与 catalog 查找表
+ * @returns 解析后的版本
+ * @internal
+ */
+const resolvePublishVersion = (
+  depName: string,
+  version: string,
+  ctx: PublishVersionContext
+): string => {
+  if (version.startsWith(PNPM_BUILT_IN_WORKSPACE)) {
+    const wsVersion = ctx.versions[depName];
+    if (!wsVersion) {
+      throw new Error(`Cannot resolve workspace version for "${depName}"`);
+    }
+
+    const protocol = version.slice(PNPM_BUILT_IN_WORKSPACE.length);
+    if (!protocol || protocol === '*') return wsVersion;
+    if (protocol === '^') return `^${wsVersion}`;
+    if (protocol === '~') return `~${wsVersion}`;
+
+    return wsVersion;
+  }
+
+  if (version.startsWith(PNPM_BUILT_IN_CATALOG)) {
+    const resolved = ctx.catalogs[version]?.[depName];
+    if (!resolved) {
+      throw new Error(
+        `Cannot resolve catalog version for "${depName}" (${version})`
+      );
+    }
+
+    return resolved;
+  }
+
+  return version;
+};
+
+/**
+ * 就地改写依赖字段中的 pnpm 协议版本。
+ * @param record - 依赖名 → 版本
+ * @param ctx - 解析上下文
+ * @internal
+ */
+const formatDependencyRecord = (
+  record: Record<string, string> | undefined,
+  ctx: PublishVersionContext
+): void => {
+  if (!record) return;
+
+  for (const [name, version] of Object.entries(record)) {
+    record[name] = resolvePublishVersion(name, version, ctx);
+  }
+};
+
+/**
+ * 构建发布用的 manifest：移除 `devDependencies` 并解析 workspace/catalog 版本。
+ * @param json - 原始 `package.json`
+ * @param ctx - 解析上下文
+ * @returns 格式化后的 manifest 副本
+ * @internal
+ */
+const formatPackageJsonForPublish = (
+  json: PackageJson,
+  ctx: PublishVersionContext
+): PackageJson => {
+  const next = structuredClone(json);
+
+  delete next.devDependencies;
+
+  for (const key of PUBLISH_DEPENDENCY_KEYS) {
+    formatDependencyRecord(next[key], ctx);
+  }
+
+  formatDependencyRecord(next.pnpm?.overrides, ctx);
+
+  return next;
+};
+
+/**
+ * 收集 monorepo 内工作区包版本与 catalog 映射。
+ * @param targetDir - 待发布包目录
+ * @returns 发布版本解析上下文
+ * @internal
+ */
+const buildPublishVersionContext = (
+  targetDir: string
+): PublishVersionContext => {
+  const workspaceRoot = findPnpmWorkspaceRoot(targetDir) ?? targetDir;
+  const workspacePackages = getWorkspacePackages(workspaceRoot);
+
+  const workspaceVersions = Object.fromEntries(
+    workspacePackages.map(pkg => [pkg.name, pkg.manifest.version || '0.0.0'])
+  );
+
+  return {
+    versions: workspaceVersions,
+    catalogs: readPnpmCatalogs(workspaceRoot)
+  };
+};
+
+/**
+ * 判断包名是否为 scoped（`@scope/name`）。
+ * @param name - `package.json` 中的 `name`
+ * @internal
+ */
+const isScopedPackageName = (name: string): boolean => name.startsWith('@');
+
+/**
+ * 在 `targetDir` 下写回格式化 manifest 并执行 `npm publish`（CI 场景，不恢复原始文件）。
+ * @param targetDir - 包根目录
+ * @param json - 原始 manifest
+ * @param ctx - 版本解析上下文
+ * @internal
+ */
+const publishPackage = (
+  targetDir: string,
+  json: PackageJson,
+  ctx: PublishVersionContext
+): void => {
+  const pkgFile = path.join(targetDir, PACKAGE_JSON_FILE);
+  const formatted = formatPackageJsonForPublish(json, ctx);
+
+  writeJsonSync(pkgFile, formatted);
+
+  const command = isScopedPackageName(json.name)
+    ? 'npm publish --access public'
+    : 'npm publish';
+
+  execSync(`${command} --no-git-checks`, { cwd: targetDir });
+};
+
+/** `publish` 命令 CLI 选项（当前无额外选项）。 */
+export interface PublishOptions extends CommandOptionsType {}
+
+/**
+ * 将单个工作区包发布到 npm registry。
+ * @example
+ * ```bash
+ * jshow publish
+ * jshow publish ./packages/core
+ * ```
+ */
+export class PublishCommand extends BaseCommand<PublishOptions> {
+  static key = 'publish';
+
+  public get args(): CommandArgs {
+    return {
+      name: 'publish',
+      group: 'devOps',
+      description: 'Publish the package to npm registry',
+      examples: ['jshow publish', 'jshow publish ./packages/core'],
+      arguments: [
+        {
+          name: 'input',
+          description: 'The input directory'
+        }
+      ]
+    };
+  }
+
+  /**
+   * 校验目标 manifest、格式化依赖版本并执行 `npm publish`。
+   * @param context - Commander 解析后的参数与选项
+   * @returns Promise<void>；校验失败时 `process.exit(1)`
+   */
+  public async execute({
+    args
+  }: CommandContext<PublishOptions>): Promise<void> {
+    let [inputRoot = '.'] = args;
+
+    inputRoot = path.resolve(inputRoot);
+
+    const cwd = process.cwd();
+    const input = path.relative(cwd, inputRoot);
+    logger.info('Start', { cwd, input });
+    logger.empty();
+
+    const pkgFile = path.join(inputRoot, PACKAGE_JSON_FILE);
+    if (!existsSync(pkgFile)) {
+      logger.error('package.json not found', { input });
+      process.exit(1);
+    }
+
+    const json = readJsonSync<PackageJson>(pkgFile);
+    if (!json?.name) {
+      logger.error('Invalid package.json', { input });
+      process.exit(1);
+    }
+
+    if (json.private) {
+      logger.error('Cannot publish private package', {
+        name: json.name
+      });
+      process.exit(1);
+    }
+
+    const ctx = buildPublishVersionContext(inputRoot);
+
+    logger.label(`Publishing ${json.name}@${json.version}...`);
+
+    try {
+      publishPackage(inputRoot, json, ctx);
+    } catch (err) {
+      logger.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+
+    logger.empty();
+    logger.info('Completed');
+  }
+}

--- a/src/built-in/commands/release.cmd.ts
+++ b/src/built-in/commands/release.cmd.ts
@@ -503,15 +503,21 @@ const releaseMultiPackages = async (
   packages: PackageInfo[],
   { check, type, force, push }: ReleaseOptions
 ) => {
+  const result = {
+    status: false,
+    count: packages.length
+  };
+
   if (check) {
-    const status = await checkPackageUncommittedForMulti(log, packages);
-    if (!status) return false;
+    result.status = await checkPackageUncommittedForMulti(log, packages);
+    if (!result.status) return result;
   }
 
   const selected = await filterReleasePackages(packages);
+  result.count = selected.length;
   if (selected.length === 0) {
     log.warn('No packages to release');
-    return false;
+    return result;
   }
 
   log.empty();
@@ -526,11 +532,13 @@ const releaseMultiPackages = async (
     selected,
     convertReleaseType(type)
   );
-  if (!versions) return false;
+  if (!versions) return result;
 
   await releasePackageForMulti(log, versions, !!force, !!push);
 
-  return true;
+  result.status = true;
+
+  return result;
 };
 
 /**
@@ -543,18 +551,25 @@ const releaseMultiPackages = async (
  */
 const releaseMonrepoPackage = async (
   log: Logger,
-  { dir, children }: PackageGroup,
+  { name, dir, children }: PackageGroup,
   { check, type, force, push }: ReleaseOptions
 ) => {
+  const result = {
+    status: false,
+    name,
+    count: children.length
+  };
+
   if (check) {
-    const status = await checkPackageUncommittedForMonorepo(log, dir);
-    if (!status) return false;
+    result.status = await checkPackageUncommittedForMonorepo(log, dir);
+    if (!result.status) return result;
   }
 
   const selected = await filterReleasePackages(children);
+  result.count = selected.length;
   if (selected.length === 0) {
     log.warn('No packages to release');
-    return false;
+    return result;
   }
 
   log.empty();
@@ -569,11 +584,13 @@ const releaseMonrepoPackage = async (
     selected,
     convertReleaseType(type)
   );
-  if (!versions) return false;
+  if (!versions) return result;
 
   await releasePackageForMonrepo(log, dir, versions, !!force, !!push);
 
-  return true;
+  result.status = true;
+
+  return result;
 };
 
 /**
@@ -700,13 +717,12 @@ export class ReleaseCommand extends BaseCommand<ReleaseOptions> {
 
       await logger.scope({ namespace: 'multi' }, async log => {
         // 多独立仓与 monorepo 可同次执行：前者按包各自 Git 根，后者在 monorepo 根统一提交
-        const status = await releaseMultiPackages(log, multiPackages, options);
+        const result = await releaseMultiPackages(log, multiPackages, options);
 
         reports.push({
           type: 'multi',
           name: '-',
-          count: multiPackages.length,
-          status
+          ...result
         });
       });
 
@@ -720,13 +736,11 @@ export class ReleaseCommand extends BaseCommand<ReleaseOptions> {
 
       for (const pkg of monorepoPackages) {
         await logger.scope({ namespace: `mrepo: ${pkg.name}` }, async log => {
-          const status = await releaseMonrepoPackage(log, pkg, options);
+          const result = await releaseMonrepoPackage(log, pkg, options);
 
           reports.push({
             type: 'mono',
-            name: pkg.name,
-            count: pkg.children.length,
-            status
+            ...result
           });
         });
         logger.empty();

--- a/src/utils/pnpm.ts
+++ b/src/utils/pnpm.ts
@@ -101,3 +101,26 @@ export const readPnpmCatalogs = (
 
   return result;
 };
+
+/**
+ * 自 `startDir` 向上查找含 `pnpm-workspace.yaml` 的 monorepo 根目录。
+ * @param startDir - 起始目录
+ * @param max - 最大递归深度
+ * @param level - 当前递归深度
+ * @returns monorepo 根绝对路径；未找到时为 `null`
+ */
+export const findPnpmWorkspaceRoot = (
+  startDir: string,
+  max: number = 3,
+  level: number = 0
+): string | null => {
+  if (max < 0 || level >= max) return null;
+
+  const fn = path.join(startDir, PNPM_WORKSPACE_FILE);
+  if (existsSync(fn)) return startDir;
+
+  const parent = path.dirname(startDir);
+  if (parent === startDir) return null;
+
+  return findPnpmWorkspaceRoot(parent, max, level + 1);
+};

--- a/test/built-in/commands/publish.cmd.test.ts
+++ b/test/built-in/commands/publish.cmd.test.ts
@@ -1,0 +1,215 @@
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+/**
+ * @fileoverview 内置命令 `publish` 契约测试
+ * @description 对齐 `publish.cmd.ts`：manifest 校验、workspace/catalog 解析与 `npm publish`。
+ */
+
+import path from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PublishCommand } from '../../../src/built-in/commands/publish.cmd';
+import type { PackageJson } from '../../../src/utils';
+import * as utils from '../../../src/utils';
+
+vi.mock('../../../src/utils', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../src/utils')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readJsonSync: vi.fn(),
+    writeJsonSync: vi.fn(),
+    execSync: vi.fn(),
+    findPnpmWorkspaceRoot: vi.fn(),
+    getWorkspacePackages: vi.fn(),
+    readPnpmCatalogs: vi.fn()
+  };
+});
+
+describe('PublishCommand', () => {
+  let publish: PublishCommand;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  const targetDir = path.resolve('/repo/packages/core');
+  const pkgFile = path.join(targetDir, 'package.json');
+
+  const baseManifest: PackageJson = {
+    name: '@scope/pkg',
+    version: '1.0.0',
+    private: false,
+    devDependencies: { vitest: '^4' },
+    dependencies: {
+      lodash: '^4.0.0',
+      'ws-pkg': 'workspace:^'
+    }
+  };
+
+  beforeEach(() => {
+    publish = new PublishCommand(new Command('publish'), []);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+
+    vi.mocked(utils.existsSync).mockImplementation(p => p === pkgFile);
+    vi.mocked(utils.readJsonSync).mockReturnValue(baseManifest);
+    vi.mocked(utils.findPnpmWorkspaceRoot).mockReturnValue('/repo');
+    vi.mocked(utils.getWorkspacePackages).mockReturnValue([
+      {
+        dir: targetDir,
+        name: 'ws-pkg',
+        manifest: { name: 'ws-pkg', version: '2.0.0' }
+      }
+    ]);
+    vi.mocked(utils.readPnpmCatalogs).mockReturnValue({});
+    vi.mocked(utils.writeJsonSync).mockImplementation(() => {});
+    vi.mocked(utils.execSync).mockReturnValue('');
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  describe('CLI 声明', () => {
+    it('static key 应为 publish', () => {
+      expect(PublishCommand.key).toBe('publish');
+    });
+
+    it('args 应声明 input 参数且无额外选项', () => {
+      const { args } = publish;
+      expect(args.name).toBe('publish');
+      expect(args.group).toBe('devOps');
+      expect(args.arguments?.map(a => a.name)).toEqual(['input']);
+      expect(args.options ?? []).toEqual([]);
+    });
+  });
+
+  describe('中止路径', () => {
+    it('缺少 package.json 时应 exit(1)', async () => {
+      vi.mocked(utils.existsSync).mockReturnValue(false);
+
+      await expect(
+        publish.execute({
+          name: 'publish',
+          args: [targetDir],
+          options: {},
+          startTime: Date.now()
+        })
+      ).rejects.toThrow('process.exit(1)');
+
+      expect(utils.execSync).not.toHaveBeenCalled();
+    });
+
+    it('manifest 无 name 时应 exit(1)', async () => {
+      vi.mocked(utils.readJsonSync).mockReturnValue({ version: '1.0.0' });
+
+      await expect(
+        publish.execute({
+          name: 'publish',
+          args: [targetDir],
+          options: {},
+          startTime: Date.now()
+        })
+      ).rejects.toThrow('process.exit(1)');
+
+      expect(utils.execSync).not.toHaveBeenCalled();
+    });
+
+    it('private 包应 exit(1)', async () => {
+      vi.mocked(utils.readJsonSync).mockReturnValue({
+        name: 'pkg',
+        version: '1.0.0',
+        private: true
+      });
+
+      await expect(
+        publish.execute({
+          name: 'publish',
+          args: [targetDir],
+          options: {},
+          startTime: Date.now()
+        })
+      ).rejects.toThrow('process.exit(1)');
+
+      expect(utils.execSync).not.toHaveBeenCalled();
+    });
+
+    it('publish 失败时应 exit(1)', async () => {
+      vi.mocked(utils.execSync).mockImplementation(() => {
+        throw new Error('npm publish failed');
+      });
+
+      await expect(
+        publish.execute({
+          name: 'publish',
+          args: [targetDir],
+          options: {},
+          startTime: Date.now()
+        })
+      ).rejects.toThrow('process.exit(1)');
+    });
+  });
+
+  describe('发布写回', () => {
+    it('应移除 devDependencies、解析 workspace: 并执行 scoped npm publish', async () => {
+      await publish.execute({
+        name: 'publish',
+        args: [targetDir],
+        options: {},
+        startTime: Date.now()
+      });
+
+      expect(utils.writeJsonSync).toHaveBeenCalled();
+      const formatted = vi.mocked(utils.writeJsonSync).mock
+        .calls[0][1] as PackageJson;
+      expect(formatted.devDependencies).toBeUndefined();
+      expect(formatted.dependencies?.['ws-pkg']).toBe('^2.0.0');
+      expect(formatted.dependencies?.lodash).toBe('^4.0.0');
+
+      expect(utils.execSync).toHaveBeenCalledWith(
+        'npm publish --access public --no-git-checks',
+        { cwd: targetDir }
+      );
+
+      expect(utils.writeJsonSync).toHaveBeenCalledTimes(1);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('非 scoped 包应使用 npm publish（无 --access public）', async () => {
+      vi.mocked(utils.readJsonSync).mockReturnValue({
+        name: 'plain-pkg',
+        version: '1.0.0',
+        private: false
+      });
+
+      await publish.execute({
+        name: 'publish',
+        args: [targetDir],
+        options: {},
+        startTime: Date.now()
+      });
+
+      expect(utils.execSync).toHaveBeenCalledWith(
+        'npm publish --no-git-checks',
+        {
+          cwd: targetDir
+        }
+      );
+    });
+
+    it('无 workspace 根时应以 targetDir 作为上下文目录', async () => {
+      vi.mocked(utils.findPnpmWorkspaceRoot).mockReturnValue(null);
+
+      await publish.execute({
+        name: 'publish',
+        args: [targetDir],
+        options: {},
+        startTime: Date.now()
+      });
+
+      expect(utils.getWorkspacePackages).toHaveBeenCalledWith(targetDir);
+      expect(utils.readPnpmCatalogs).toHaveBeenCalledWith(targetDir);
+    });
+  });
+});

--- a/test/program.test.ts
+++ b/test/program.test.ts
@@ -10,6 +10,7 @@ import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BackupCommand } from '../src/built-in/commands/backup.cmd';
+import { PublishCommand } from '../src/built-in/commands/publish.cmd';
 import { ReleaseCommand } from '../src/built-in/commands/release.cmd';
 import { UpgradeCommand } from '../src/built-in/commands/upgrade.cmd';
 import { BaseCommand, type CommandArgs, isCommand } from '../src/command';
@@ -159,15 +160,16 @@ describe('initBuiltIn', () => {
     CommandProgram.reset();
   });
 
-  it('应注册 backup、release、upgrade 内置命令', async () => {
+  it('应注册 backup、publish、release、upgrade 内置命令', async () => {
     initBuiltIn(CommandProgram);
     await CommandProgram.run();
 
     const names = CommandProgram.program.commands.map(c => c.name());
     expect(names).toEqual(
-      expect.arrayContaining(['backup', 'release', 'upgrade'])
+      expect.arrayContaining(['backup', 'publish', 'release', 'upgrade'])
     );
     expect(isCommand(BackupCommand)).toBe(true);
+    expect(isCommand(PublishCommand)).toBe(true);
     expect(isCommand(ReleaseCommand)).toBe(true);
     expect(isCommand(UpgradeCommand)).toBe(true);
   });

--- a/test/utils/pnpm.test.ts
+++ b/test/utils/pnpm.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview `utils/pnpm` 契约测试
+ * @description 对齐 `findPnpmWorkspaceRoot`：向上查找 `pnpm-workspace.yaml` 与深度上限。
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  findPnpmWorkspaceRoot,
+  PNPM_WORKSPACE_FILE
+} from '../../src/utils/pnpm';
+
+describe('findPnpmWorkspaceRoot', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const mkTmp = () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jshow-pnpm-'));
+    tmpDirs.push(dir);
+    return dir;
+  };
+
+  it('startDir 含 workspace 文件时应返回该目录', () => {
+    const root = mkTmp();
+    fs.writeFileSync(
+      path.join(root, PNPM_WORKSPACE_FILE),
+      'packages:\n  - packages/*\n'
+    );
+
+    expect(findPnpmWorkspaceRoot(root)).toBe(root);
+  });
+
+  it('应向上查找父目录中的 workspace 根', () => {
+    const root = mkTmp();
+    const child = path.join(root, 'packages', 'core');
+    fs.mkdirSync(child, { recursive: true });
+    fs.writeFileSync(
+      path.join(root, PNPM_WORKSPACE_FILE),
+      'packages:\n  - packages/*\n'
+    );
+
+    expect(findPnpmWorkspaceRoot(child)).toBe(root);
+  });
+
+  it('默认 max=3 时超过深度应返回 null', () => {
+    const root = mkTmp();
+    const deep = path.join(root, 'a', 'b', 'c', 'd');
+    fs.mkdirSync(deep, { recursive: true });
+    fs.writeFileSync(
+      path.join(root, PNPM_WORKSPACE_FILE),
+      'packages:\n  - packages/*\n'
+    );
+
+    expect(findPnpmWorkspaceRoot(deep)).toBeNull();
+  });
+
+  it('自定义 max 足够时应找到更深层级上的根', () => {
+    const root = mkTmp();
+    const deep = path.join(root, 'a', 'b', 'c', 'd');
+    fs.mkdirSync(deep, { recursive: true });
+    fs.writeFileSync(
+      path.join(root, PNPM_WORKSPACE_FILE),
+      'packages:\n  - packages/*\n'
+    );
+
+    expect(findPnpmWorkspaceRoot(deep, 10)).toBe(root);
+  });
+
+  it('无 workspace 文件时应返回 null', () => {
+    const dir = mkTmp();
+    const leaf = path.join(dir, 'only', 'pkg');
+    fs.mkdirSync(leaf, { recursive: true });
+
+    expect(findPnpmWorkspaceRoot(leaf)).toBeNull();
+  });
+
+  it('max < 0 时应立即返回 null', () => {
+    expect(findPnpmWorkspaceRoot('/any', -1)).toBeNull();
+  });
+});


### PR DESCRIPTION
- Add publish command to validate a single package, resolve workspace/catalog deps, and npm publish with manifest restore
- Add findPnpmWorkspaceRoot helper for upward pnpm-workspace.yaml lookup
- Extend release report table with status and count for selected packages
- Document publish in README and docs/publish.md; add unit tests